### PR TITLE
fix: increase prompt-editor z-index to 30 to prevent activity-dock overlap

### DIFF
--- a/src/client/src/components/shared.ts
+++ b/src/client/src/components/shared.ts
@@ -442,7 +442,7 @@ export const actionPaletteStyles = css`
 `;
 
 export const promptEditorStyles = css`
-  :host { position: relative; z-index: 5; display: block; color: var(--pi-text); font: 14px system-ui, sans-serif; }
+  :host { position: relative; z-index: 30; display: block; color: var(--pi-text); font: 14px system-ui, sans-serif; }
   footer { display: grid; grid-template-columns: minmax(0, 1fr); gap: 8px; padding: 12px; border-top: 1px solid var(--pi-border); }
   footer.shell-mode { border-top-color: var(--pi-success); background: var(--pi-success-bg); }
   .editor-wrap { position: relative; min-width: 0; }


### PR DESCRIPTION
## Problem

The `prompt-editor` host has `z-index: 5`, which is lower than the `activity-dock` (`z-index: 20`). 
This causes the activity-dock to overlap the autocomplete menu when typing `/` commands, 
making it impossible to see and interact with the command suggestions.

## Root Cause

In `src/client/src/components/shared.ts`, the `promptEditorStyles` defines:
```css
:host { position: relative; z-index: 5; ... }
```
Since `activity-dock` has `z-index: 20`, it stacks above the entire `prompt-editor` 
and its children, including the autocomplete menu.

## Fix

Increased `prompt-editor` `:host` z-index from `5` to `30`:
```css
:host { position: relative; z-index: 30; ... }
```

## Tested

Verified locally that the autocomplete menu now renders correctly above the activity-dock.