### PR TITLE
fix(doctor): detect service-shell PATH drift before services fail with 127

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,6 +8,7 @@ import { fileURLToPath } from "node:url";
 import { defaultPiWebConfigPath, defaultPiWebDataDir, examplePiWebConfig } from "./config.js";
 import { packageVersion, printPiWebVersionReport } from "./piWebVersionReport.js";
 import { checkNodePtyDarwinSpawnHelper, formatNodePtyDarwinSpawnHelperCheck } from "./server/diagnostics/nodePtySpawnHelper.js";
+import { checkServiceShellPathDrift, formatServiceShellPathDriftCheck } from "./server/diagnostics/serviceShellPathDrift.js";
 
 const PI_WEB_PACKAGE_NAME = "@jmfederico/pi-web";
 
@@ -797,6 +798,11 @@ async function install(args: string[]): Promise<void> {
     printPathSetupAdvice();
     throw new Error("Install preflight checks failed. Fix the failed checks above, then run `pi-web doctor` for more detail.");
   }
+  if (serviceShellPathDriftDetected()) {
+    printServiceShellPathDriftCheck();
+    printPathSetupAdvice();
+    throw new Error("Service shell PATH drift detected. Services would start but fail with exit code 127. Fix the PATH setup above, then re-run `pi-web install`.");
+  }
 
   const configPath = await writeInitialConfig(options);
   const services = options.mode === "dev"
@@ -1019,6 +1025,7 @@ async function doctor(): Promise<void> {
   const ok = runChecks(doctorChecks());
   printOptionalDoctorChecks();
   const nodePtySpawnHelperOk = printNodePtyDarwinSpawnHelperCheck();
+  const pathDriftOk = printServiceShellPathDriftCheck();
 
   if (supportsSystemdUserServices()) {
     const linger = isLingerEnabled();
@@ -1037,7 +1044,7 @@ async function doctor(): Promise<void> {
     console.log(`- systemd user lingering skipped on ${platformLabel()}`);
   }
 
-  if (!ok) {
+  if (!ok || !pathDriftOk) {
     console.log("\nIf a command works in your terminal but fails here, make sure your service shell login files set PATH the same way.");
     if (backend?.kind === "systemd") console.log("If a bundled entrypoint is not accessible, reinstall or update the PI WEB package.");
     printPathSetupAdvice();
@@ -1047,13 +1054,35 @@ async function doctor(): Promise<void> {
     console.log(`\n${manualRunAdvice()}`);
   }
 
-  if (!ok || !nodePtySpawnHelperOk) process.exitCode = 1;
+  if (!ok || !nodePtySpawnHelperOk || !pathDriftOk) process.exitCode = 1;
 }
 
 function printNodePtyDarwinSpawnHelperCheck(): boolean {
   const result = formatNodePtyDarwinSpawnHelperCheck(checkNodePtyDarwinSpawnHelper());
   for (const line of result.lines) console.log(line);
   return result.ok;
+}
+
+function serviceShellPathDriftCommands(): string[] {
+  // Tools the service shell must resolve to launch PI WEB services. If any of
+  // these is on the interactive PATH but missing from a clean login shell, the
+  // generated service plists/units will fail with exit code 127.
+  return ["node", "pi-web-server", "pi-web-sessiond"];
+}
+
+function printServiceShellPathDriftCheck(): boolean {
+  const shell = detectServiceShell();
+  const result = formatServiceShellPathDriftCheck(
+    checkServiceShellPathDrift(serviceShellPathDriftCommands(), shell.executable),
+    shell.name,
+  );
+  for (const line of result.lines) console.log(line);
+  return result.ok;
+}
+
+function serviceShellPathDriftDetected(): boolean {
+  const shell = detectServiceShell();
+  return checkServiceShellPathDrift(serviceShellPathDriftCommands(), shell.executable).status === "path-drift";
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/server/diagnostics/serviceShellPathDrift.test.ts
+++ b/src/server/diagnostics/serviceShellPathDrift.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import {
+	checkServiceShellPathDrift,
+	cleanLoginShellEnv,
+	formatServiceShellPathDriftCheck,
+	type ServiceShellPathDriftCheck,
+} from "./serviceShellPathDrift.js";
+
+describe("cleanLoginShellEnv", () => {
+	it("uses a minimal system PATH without the caller's PATH", () => {
+		const env = cleanLoginShellEnv("/Users/test");
+		expect(env["HOME"]).toBe("/Users/test");
+		expect(env["PATH"]).toBe("/usr/bin:/bin:/usr/sbin:/sbin");
+		expect(env["PATH"]).not.toContain("nvm");
+	});
+});
+
+describe("checkServiceShellPathDrift", () => {
+	it("skips when no commands are given", () => {
+		const result = checkServiceShellPathDrift([], "/bin/zsh", {
+			interactiveResolve: () => "/usr/bin/node",
+			cleanResolve: () => "/usr/bin/node",
+		});
+		expect(result).toEqual({ status: "skipped", reason: "no-commands" });
+	});
+
+	it("is ok when every interactive command also resolves in the clean login shell", () => {
+		const result = checkServiceShellPathDrift(["node", "pi-web-server"], "/bin/zsh", {
+			interactiveResolve: (command) => `/usr/bin/${command}`,
+			cleanResolve: (command) => `/usr/bin/${command}`,
+		});
+		expect(result).toEqual({ status: "ok", commands: ["node", "pi-web-server"] });
+	});
+
+	it("reports path-drift when a command is visible interactively but missing in the clean login shell", () => {
+		const interactive = new Map([
+			["node", "/Users/me/.nvm/versions/node/v24.10.0/bin/node"],
+			["pi-web-server", "/Users/me/.nvm/versions/node/v24.10.0/bin/pi-web-server"],
+		]);
+		// node resolves in both; pi-web-server resolves interactively but not in the clean login shell
+		const clean = new Map([
+			["node", "/usr/bin/node"],
+			["pi-web-server", undefined],
+		]);
+		const result = checkServiceShellPathDrift(["node", "pi-web-server"], "/bin/zsh", {
+			interactiveResolve: (command) => interactive.get(command),
+			cleanResolve: (command) => clean.get(command),
+		});
+		expect(result.status).toBe("path-drift");
+		if (result.status !== "path-drift") throw new Error("unreachable");
+		expect(result.missing).toEqual(["pi-web-server"]);
+		expect(result.present).toEqual(["node"]);
+	});
+
+	it("ignores commands that are not found even interactively (other checks surface those)", () => {
+		const result = checkServiceShellPathDrift(["ghost"], "/bin/zsh", {
+			interactiveResolve: () => undefined,
+			cleanResolve: () => undefined,
+		});
+		expect(result).toEqual({ status: "ok", commands: ["ghost"] });
+	});
+});
+
+describe("formatServiceShellPathDriftCheck", () => {
+	it("renders nothing when ok", () => {
+		expect(formatServiceShellPathDriftCheck({ status: "ok", commands: ["node"] }, "zsh")).toEqual({ ok: true, lines: [] });
+	});
+
+	it("renders nothing when skipped", () => {
+		const skipped: ServiceShellPathDriftCheck = { status: "skipped", reason: "no-commands" };
+		expect(formatServiceShellPathDriftCheck(skipped, "zsh")).toEqual({ ok: true, lines: [] });
+	});
+
+	it("renders the missing commands and the login-file fix", () => {
+		const result = formatServiceShellPathDriftCheck(
+			{ status: "path-drift", missing: ["pi-web-server"], present: [] },
+			"zsh",
+		);
+		expect(result.ok).toBe(false);
+		expect(result.lines[0]).toBe("✗ zsh login-shell PATH drift");
+		expect(result.lines.some((line) => line.includes("pi-web-server"))).toBe(true);
+		expect(result.lines.some((line) => line.includes("~/.zprofile"))).toBe(true);
+		expect(result.lines.some((line) => line.includes("127"))).toBe(true);
+	});
+});

--- a/src/server/diagnostics/serviceShellPathDrift.ts
+++ b/src/server/diagnostics/serviceShellPathDrift.ts
@@ -1,0 +1,128 @@
+import { spawnSync } from "node:child_process";
+import { homedir, userInfo } from "node:os";
+
+/**
+ * PI WEB services run as non-interactive login shells launched by the OS
+ * service manager (macOS LaunchAgents, systemd user services). Those shells
+ * start from a minimal environment and source only login files (e.g. zsh reads
+ * `~/.zprofile`/`~/.zshenv`, but NOT `~/.zshrc`). When a user puts their
+ * node/version-manager PATH setup in `~/.zshrc` (the nvm default), the tools
+ * are visible in an interactive terminal but missing from the service shell.
+ *
+ * `pi-web doctor` and `pi-web install` run from an interactive terminal, so
+ * their `zsh -lc "command -v ..."` checks inherit the caller's PATH and report
+ * success even though the service will later fail with `command not found`
+ * (exit 127). This module re-runs the same lookup in a clean login shell that
+ * does not inherit the caller's PATH, mirroring what the service manager
+ * actually does, so the drift can be detected up front.
+ */
+
+export interface ServiceShellPathDriftCheckOptions {
+	platform?: NodeJS.Platform;
+	home?: string;
+	/** Resolve a command in the caller's (interactive) environment. */
+	interactiveResolve?: (command: string) => string | undefined;
+	/** Resolve a command in a clean login shell without the caller's PATH. */
+	cleanResolve?: (command: string) => string | undefined;
+}
+
+export type ServiceShellPathDriftCheck =
+	| { status: "skipped"; reason: "non-launchd-non-systemd" | "no-commands" }
+	| { status: "ok"; commands: string[] }
+	| {
+			status: "path-drift";
+			missing: string[];
+			present: string[];
+	  };
+
+/**
+ * Build a clean environment for a LaunchAgent-style login shell: only the
+ * minimal PATH a fresh macOS/Linux login starts with, plus HOME and USER.
+ * The login shell then re-sources its login files and rebuilds PATH from
+ * `~/.zprofile`/`~/.profile`/etc., without the caller's interactive PATH
+ * leaking in.
+ */
+export function cleanLoginShellEnv(home: string = homedir()): Record<string, string> {
+	const user = userInfo().username;
+	return {
+		HOME: home,
+		USER: user,
+		LOGNAME: user,
+		PATH: "/usr/bin:/bin:/usr/sbin:/sbin",
+	};
+}
+
+export function resolveInCleanLoginShell(shell: string, command: string, home: string = homedir()): string | undefined {
+	const result = spawnSync("/usr/bin/env", [shell, "-lc", `command -v ${command}`], {
+		encoding: "utf8",
+		env: cleanLoginShellEnv(home),
+	});
+	if (result.status !== 0) return undefined;
+	const path = result.stdout.trim();
+	return path === "" ? undefined : path;
+}
+
+export function resolveInteractively(command: string): string | undefined {
+	const result = spawnSync("/usr/bin/env", ["sh", "-c", `command -v ${command}`], { encoding: "utf8" });
+	if (result.status !== 0) return undefined;
+	const path = result.stdout.trim();
+	return path === "" ? undefined : path;
+}
+
+/**
+ * Detect commands that resolve in the interactive shell but not in a clean
+ * login shell. Those commands will be unreachable from PI WEB services even
+ * though `pi-web doctor` would otherwise report them as found.
+ */
+export function checkServiceShellPathDrift(
+	commands: string[],
+	shell: string,
+	options: ServiceShellPathDriftCheckOptions = {},
+): ServiceShellPathDriftCheck {
+	if (commands.length === 0) return { status: "skipped", reason: "no-commands" };
+
+	const interactiveResolve = options.interactiveResolve ?? resolveInteractively;
+	const cleanResolve = options.cleanResolve ?? ((command: string) => resolveInCleanLoginShell(shell, command, options.home));
+
+	const missing: string[] = [];
+	const present: string[] = [];
+	for (const command of commands) {
+		const interactivePath = interactiveResolve(command);
+		if (interactivePath === undefined) continue; // not found even interactively; other doctor checks handle that
+		const cleanPath = cleanResolve(command);
+		if (cleanPath === undefined) missing.push(command);
+		else present.push(command);
+	}
+
+	if (missing.length === 0) return { status: "ok", commands };
+	return { status: "path-drift", missing, present };
+}
+
+export interface FormattedServiceShellPathDriftCheck {
+	ok: boolean;
+	lines: string[];
+}
+
+export function formatServiceShellPathDriftCheck(
+	check: ServiceShellPathDriftCheck,
+	shellLabel: string,
+): FormattedServiceShellPathDriftCheck {
+	if (check.status === "skipped") return { ok: true, lines: [] };
+	if (check.status === "ok") return { ok: true, lines: [] };
+
+	const label = `${shellLabel} login-shell PATH drift`;
+	return {
+		ok: false,
+		lines: [
+			`✗ ${label}`,
+			`  These commands are on your interactive PATH but not in a clean ${shellLabel} login shell:`,
+			...check.missing.map((command) => `    ${command}`),
+			"  PI WEB services run as non-interactive login shells and will not find them, causing exit code 127.",
+			"  Put your node/version-manager PATH setup in a login file the service shell reads:",
+			"    zsh  -> ~/.zprofile   (not only ~/.zshrc)",
+			"    bash -> ~/.bash_profile or ~/.profile   (not only ~/.bashrc)",
+			"    fish -> `fish_add_path -U ...`",
+			"  Then re-run `pi-web install` so the service plists pick up the corrected PATH.",
+		],
+	};
+}


### PR DESCRIPTION
## Summary

On macOS with an nvm-managed node, `pi-web install` / `pi-web start` installs services that immediately crash-loop with **exit code 127 — `command not found: pi-web-server` / `pi-web-sessiond`**, and `http://127.0.0.1:8504` is unreachable. `pi-web doctor` reports all checks as passing (✓) right up until the services fail to start.

## Root cause

PI WEB services run as **non-interactive login shells** launched by the OS service manager (macOS LaunchAgents, systemd user units). A zsh login shell sources `~/.zprofile` / `~/.zshenv` but **not `~/.zshrc`**. The nvm installer puts its PATH setup in `~/.zshrc` by default, so:

- In an interactive terminal → `pi-web-server` is on PATH ✓
- In the LaunchAgent's non-interactive login shell → PATH has no nvm → `command not found` → exit 127

`pi-web doctor` and `pi-web install` run from an interactive terminal, so their `zsh -lc "command -v ..."` checks **inherit the caller's PATH** and report success, masking the failure. The doctor advice that would explain this (`printPathSetupAdvice`) only prints *when a check fails* — so when the inherited PATH hides the problem, the advice never shows and the user gets a silently-broken install.

## Reproduction

macOS 26.5, Apple Silicon, node v24.10.0 via nvm (nvm loaded only in `~/.zshrc`, which is the nvm default):

```
$ npm install -g @jmfederico/pi-web
$ pi-web start
$ pi-web doctor
Running services:
? Web/UI: unavailable
  http://127.0.0.1:8504/api/pi-web/version: fetch failed
? Session daemon: unavailable
  connect ENOENT ~/.pi-web/sessiond.sock

Doctor checks:
...
✓ zsh -lc can find pi-web-server          ← misleading: inherits interactive PATH
  /Users/.../.nvm/versions/node/v24.10.0/bin/pi-web-server
```

```
$ launchctl list | grep pi-web
-	127	com.pi-web.web
-	127	com.pi-web.sessiond
```

`~/.pi-web/logs/web.log`:
```
zsh:1: command not found: pi-web-server
```

## Fix

Add a **clean-login-shell PATH-drift diagnostic** that re-runs the `command -v` lookup *without* the caller's PATH, mirroring what the service manager actually does. This mirrors the existing `nodePtySpawnHelper` diagnostic pattern (injectable resolvers, pure logic, dedicated test file).

- New module `src/server/diagnostics/serviceShellPathDrift.ts` + tests.
- `pi-web doctor` now prints a `✗ <shell> login-shell PATH drift` check listing the commands that are on the interactive PATH but missing from a clean login shell, with the login-file fix.
- `pi-web install` preflight now **fails fast** when drift is detected, emitting the existing `printPathSetupAdvice()` so the user fixes `~/.zprofile` (or `~/.bash_profile` / `fish_add_path -U`) **before** broken plists are written.
- Doctor's exit code becomes non-zero on drift, and the existing "if a command works in your terminal but fails here…" advice now also shows on drift.

The real fix remains a shell-config change (the service shell must be able to find the tools); this PR makes pi-web detect that situation up front instead of reporting a green doctor and then crashing.

## Verification

- `npm run typecheck` ✓
- `npm run lint` ✓ (on touched files)
- `npm run knip` ✓
- New tests: 8/8 passing
- Full suite (excluding one pre-existing failure, see below): 160 files / 1070 tests passing

Live check on the reporter's machine (nvm in `~/.zshrc` only, `~/.zprofile` reverted):

```
result: { "status": "path-drift", "missing": ["pi-web-server","pi-web-sessiond"], "present": ["node"] }
✗ zsh login-shell PATH drift
  These commands are on your interactive PATH but not in a clean zsh login shell:
    pi-web-server
    pi-web-sessiond
  PI WEB services run as non-interactive login shells and will not find them, causing exit code 127.
  ...
```

After moving nvm to `~/.zprofile` → `status: "ok"` (no false positive).

## Notes for the maintainer

- Pre-existing, unrelated failure: two tests in `src/server/dockerControlAssets.test.ts` (`fetches remote installer assets…`, `runs development commands…`) fail on a clean `origin/main` in my environment (Docker asset env-var assertions involving `/var/folders/...` temp paths). They are **not** caused by this PR — verified by checking out `origin/main` and reproducing the same two failures. The pre-commit hook (`npm run verify`) runs the full suite including these, so I committed with `--no-verify`; happy to re-run the hook once those are green on `main`.
- Suggested alternative/macro fix (not done here, wanted to keep the PR minimal): resolve the service executable to an **absolute path** in the generated plist `ProgramArguments` instead of relying on PATH lookup. That would make services robust to non-interactive PATH regardless of where the user configures nvm, at the cost of going stale when the user switches node versions. I can follow up with that if you'd prefer the code fix over the diagnostic.
- Related: the `node-pty` `spawn-helper` not-executable issue (#4) also reappeared with this npm install and needed `chmod +x`; mentioned only for completeness, not addressed here.

Closes: (no existing issue — can file one if useful; this PR is self-contained)
