### PR TITLE
fix: show tool result images outside event groups

### DIFF
--- a/.changeset/show-tool-images-outside-events.md
+++ b/.changeset/show-tool-images-outside-events.md
@@ -1,0 +1,5 @@
+---
+"@jmfederico/pi-web": patch
+---
+
+Keep image content from tool results visible outside collapsed event groups while retaining technical tool metadata inside the group.

--- a/src/client/src/chatGroups.test.ts
+++ b/src/client/src/chatGroups.test.ts
@@ -41,6 +41,34 @@ describe("groupChatMessages", () => {
     ]);
   });
 
+  it("keeps image content visible outside collapsed event groups", () => {
+    const image = { type: "image" as const, mimeType: "image/png", data: "QUJD" };
+    const messages: ChatLine[] = [
+      { role: "tool", parts: [{ type: "toolResult", toolName: "read", text: "Read image file [image/png]", isError: false }, image] },
+    ];
+
+    expect(groupChatMessages(messages)).toEqual([
+      {
+        kind: "group",
+        startIndex: 0,
+        endIndex: 0,
+        messages: [{ role: "tool", parts: [{ type: "toolResult", toolName: "read", text: "Read image file [image/png]", isError: false }] }],
+      },
+      { kind: "message", index: 0, message: { role: "tool", parts: [image] } },
+    ]);
+  });
+
+  it("preserves image metadata when splitting technical and readable parts", () => {
+    const meta = { timestamp: "2026-07-13T22:00:00.000Z" };
+    const image = { type: "image" as const, mimeType: "image/webp", data: "QUJD" };
+    const message: ChatLine = { role: "tool", parts: [{ type: "toolResult", toolName: "read", text: "ok", isError: false }, image], meta };
+
+    expect(groupChatMessages([message])).toEqual([
+      { kind: "group", startIndex: 0, endIndex: 0, messages: [{ role: "tool", parts: [message.parts[0]], meta }] },
+      { kind: "message", index: 0, message: { role: "tool", parts: [image], meta } },
+    ]);
+  });
+
   it("preserves message metadata when grouping", () => {
     const message: ChatLine = { role: "assistant", parts: [{ type: "thinking", text: "hidden" }, { type: "text", text: "shown" }], meta: { timestamp: "2026-05-09T12:00:00.000Z", model: { provider: "test", id: "model" } } };
 

--- a/src/client/src/chatGroups.ts
+++ b/src/client/src/chatGroups.ts
@@ -49,6 +49,6 @@ export function summarizeChatGroup(messages: ChatLine[]): string {
 
 function isReadablePart(message: ChatLine, part: ChatPart): boolean {
   if (message.source === "compaction" || message.source === "branch_summary") return false;
-  if (part.type === "skillInvocation" || part.type === "skillRead") return true;
+  if (part.type === "skillInvocation" || part.type === "skillRead" || part.type === "image") return true;
   return part.type === "text" && (message.role === "user" || message.role === "assistant" || message.role === "system" || message.role === "bash");
 }


### PR DESCRIPTION
## Summary

- treat native image parts as readable chat content so tool-produced images remain visible outside collapsed event groups
- keep the associated tool call/result metadata in the technical EVENTS group
- preserve message metadata when splitting technical and readable parts

## Why

Pi Web already renders native `ImageContent`, but `chatGroups.ts` classified every image as technical. Once the assistant emitted readable text, the event group collapsed and mobile users had to reopen EVENTS to see a screenshot or QR code produced by a tool.

## Validation

- `npx vitest run --config vitest.config.ts src/client/src/chatGroups.test.ts src/client/src/components/ChatView.test.ts`
- `npm run verify` — 166 test files, 1117 passed, 2 skipped
- pre-commit `npm run verify:staged` passed
- also applied to the current released baseline `v1.202606.7`: 108 test files / 787 tests passed
- canary-tested on a 412px mobile Pi Web session: image visible without opening EVENTS; operator confirmed
