### PR TITLE
feat(terminals): set PI WEB shell environment

### DIFF
--- a/.changeset/add-pi-web-terminal-environment.md
+++ b/.changeset/add-pi-web-terminal-environment.md
@@ -2,4 +2,4 @@
 "@jmfederico/pi-web": patch
 ---
 
-Set `IS_PIWEB=1` in PI WEB terminal shells.
+Set `PI_WEB_TERMINAL=1` in PI WEB terminal shells.

--- a/.changeset/add-pi-web-terminal-environment.md
+++ b/.changeset/add-pi-web-terminal-environment.md
@@ -1,0 +1,5 @@
+---
+"@jmfederico/pi-web": patch
+---
+
+Set `IS_PIWEB=1` in PI WEB terminal shells.

--- a/package.json
+++ b/package.json
@@ -140,8 +140,5 @@
       "./extensions"
     ],
     "image": "https://raw.githubusercontent.com/jmfederico/pi-web/main/docs/assets/pi-web-banner.png"
-  },
-  "allowScripts": {
-    "node-pty@1.1.0": true
   }
 }

--- a/package.json
+++ b/package.json
@@ -140,5 +140,8 @@
       "./extensions"
     ],
     "image": "https://raw.githubusercontent.com/jmfederico/pi-web/main/docs/assets/pi-web-banner.png"
+  },
+  "allowScripts": {
+    "node-pty@1.1.0": true
   }
 }

--- a/src/server/terminals/terminalService.test.ts
+++ b/src/server/terminals/terminalService.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { RealtimeEvent, TerminalInfo } from "../../shared/apiTypes.js";
 import type { WorkspaceActivityService } from "../activity/workspaceActivityService.js";
 import { SessionEventHub } from "../realtime/sessionEventHub.js";
@@ -22,22 +22,71 @@ describe.skipIf(process.platform === "win32")("TerminalService command runs", ()
     }
   });
 
-  it("sets IS_PIWEB for terminal commands", async () => {
-    const service = new TerminalService();
-    try {
-      const run = service.runCommand({
-        origin: "core",
-        projectId: "p1",
-        workspaceId: "w1",
-        cwd: process.cwd(),
-        title: "Environment check",
-        command: "printf '%s' \"$IS_PIWEB\"",
-      });
+  describe("IS_PIWEB propagation", () => {
+    let originalIsPiWeb: string | undefined;
 
-      expect(await terminalExit(service, run.terminalId)).toContain("1");
-    } finally {
-      service.dispose();
-    }
+    beforeEach(() => {
+      originalIsPiWeb = process.env["IS_PIWEB"];
+      process.env["IS_PIWEB"] = "conflicting-parent-value";
+    });
+
+    afterEach(() => {
+      if (originalIsPiWeb === undefined) {
+        delete process.env["IS_PIWEB"];
+      } else {
+        process.env["IS_PIWEB"] = originalIsPiWeb;
+      }
+    });
+
+    it("sets IS_PIWEB for terminal commands", async () => {
+      const service = new TerminalService();
+      try {
+        const frame = "__PI_WEB_RUN_ENV_7F3A9C__";
+        const run = service.runCommand({
+          origin: "core",
+          projectId: "p1",
+          workspaceId: "w1",
+          cwd: process.cwd(),
+          title: "Environment check",
+          command: `printf '${frame}%s${frame}\\n' "$IS_PIWEB"`,
+        });
+
+        expect(await terminalExit(service, run.terminalId)).toContain(`${frame}1${frame}`);
+      } finally {
+        service.dispose();
+      }
+    });
+
+    it("sets IS_PIWEB in a continued interactive shell", async () => {
+      const service = new TerminalService();
+      try {
+        const run = service.runCommand({
+          origin: "core",
+          projectId: "p1",
+          workspaceId: "w1",
+          cwd: process.cwd(),
+          title: "Done command",
+          command: "true",
+        });
+        await terminalExit(service, run.terminalId);
+
+        const continued = service.continue(run.terminalId);
+
+        expect(continued).toMatchObject({ id: run.terminalId, exited: false });
+        expect(continued.commandRunId).toBeUndefined();
+        expect(service.get(run.terminalId)?.commandRunId).toBeUndefined();
+
+        const frame = "__PI_WEB_CONTINUE_ENV_42D8B1__";
+        const exit = terminalExit(service, run.terminalId);
+        service.write(run.terminalId, `printf '${frame}%s${frame}\\n' "$IS_PIWEB"\nexit\n`);
+
+        const output = await exit;
+        expect(output).toContain("[continued in interactive shell]");
+        expect(output).toContain(`${frame}1${frame}`);
+      } finally {
+        service.dispose();
+      }
+    });
   });
 
   it("tracks dedicated terminal command runs through completion", async () => {
@@ -63,30 +112,6 @@ describe.skipIf(process.platform === "win32")("TerminalService command runs", ()
       expect(output).toContain("hello");
       expect(service.getCommandRun(run.id)).toMatchObject({ status: "succeeded", exitCode: 0, terminalId: run.terminalId });
       expect(service.listCommandRuns({ statuses: ["succeeded"] }).map((candidate) => candidate.id)).toEqual([run.id]);
-    } finally {
-      service.dispose();
-    }
-  });
-
-  it("continues an exited command-run terminal as an interactive shell", async () => {
-    const service = new TerminalService();
-    try {
-      const run = service.runCommand({
-        origin: "core",
-        projectId: "p1",
-        workspaceId: "w1",
-        cwd: process.cwd(),
-        title: "Done command",
-        command: "true",
-      });
-      await terminalExit(service, run.terminalId);
-
-      const continued = service.continue(run.terminalId);
-
-      expect(continued).toMatchObject({ id: run.terminalId, exited: false });
-      expect(continued.commandRunId).toBeUndefined();
-      expect(service.get(run.terminalId)?.commandRunId).toBeUndefined();
-      expect(await terminalReplay(service, run.terminalId)).toContain("[continued in interactive shell]");
     } finally {
       service.dispose();
     }
@@ -196,16 +221,6 @@ function requireTerminal(service: TerminalService, terminalId: string): Terminal
   const terminal = service.get(terminalId);
   if (terminal === undefined) throw new Error(`Expected terminal ${terminalId} to exist`);
   return terminal;
-}
-
-function terminalReplay(service: TerminalService, terminalId: string): Promise<string> {
-  let output = "";
-  const detach = service.attach(terminalId, {
-    output: (data) => { output += data; },
-    exit: () => undefined,
-  });
-  detach();
-  return Promise.resolve(output);
 }
 
 function terminalExit(service: TerminalService, terminalId: string): Promise<string> {

--- a/src/server/terminals/terminalService.test.ts
+++ b/src/server/terminals/terminalService.test.ts
@@ -22,23 +22,23 @@ describe.skipIf(process.platform === "win32")("TerminalService command runs", ()
     }
   });
 
-  describe("IS_PIWEB propagation", () => {
-    let originalIsPiWeb: string | undefined;
+  describe("PI_WEB_TERMINAL propagation", () => {
+    let originalPiWebTerminal: string | undefined;
 
     beforeEach(() => {
-      originalIsPiWeb = process.env["IS_PIWEB"];
-      process.env["IS_PIWEB"] = "conflicting-parent-value";
+      originalPiWebTerminal = process.env["PI_WEB_TERMINAL"];
+      process.env["PI_WEB_TERMINAL"] = "conflicting-parent-value";
     });
 
     afterEach(() => {
-      if (originalIsPiWeb === undefined) {
-        delete process.env["IS_PIWEB"];
+      if (originalPiWebTerminal === undefined) {
+        delete process.env["PI_WEB_TERMINAL"];
       } else {
-        process.env["IS_PIWEB"] = originalIsPiWeb;
+        process.env["PI_WEB_TERMINAL"] = originalPiWebTerminal;
       }
     });
 
-    it("sets IS_PIWEB for terminal commands", async () => {
+    it("sets PI_WEB_TERMINAL for terminal commands", async () => {
       const service = new TerminalService();
       try {
         const frame = "__PI_WEB_RUN_ENV_7F3A9C__";
@@ -48,7 +48,7 @@ describe.skipIf(process.platform === "win32")("TerminalService command runs", ()
           workspaceId: "w1",
           cwd: process.cwd(),
           title: "Environment check",
-          command: `printf '${frame}%s${frame}\\n' "$IS_PIWEB"`,
+          command: `printf '${frame}%s${frame}\\n' "$PI_WEB_TERMINAL"`,
         });
 
         expect(await terminalExit(service, run.terminalId)).toContain(`${frame}1${frame}`);
@@ -57,7 +57,7 @@ describe.skipIf(process.platform === "win32")("TerminalService command runs", ()
       }
     });
 
-    it("sets IS_PIWEB in a continued interactive shell", async () => {
+    it("sets PI_WEB_TERMINAL in a continued interactive shell", async () => {
       const service = new TerminalService();
       try {
         const run = service.runCommand({
@@ -78,7 +78,7 @@ describe.skipIf(process.platform === "win32")("TerminalService command runs", ()
 
         const frame = "__PI_WEB_CONTINUE_ENV_42D8B1__";
         const exit = terminalExit(service, run.terminalId);
-        service.write(run.terminalId, `printf '${frame}%s${frame}\\n' "$IS_PIWEB"\nexit\n`);
+        service.write(run.terminalId, `printf '${frame}%s${frame}\\n' "$PI_WEB_TERMINAL"\nexit\n`);
 
         const output = await exit;
         expect(output).toContain("[continued in interactive shell]");

--- a/src/server/terminals/terminalService.test.ts
+++ b/src/server/terminals/terminalService.test.ts
@@ -22,6 +22,24 @@ describe.skipIf(process.platform === "win32")("TerminalService command runs", ()
     }
   });
 
+  it("sets IS_PIWEB for terminal commands", async () => {
+    const service = new TerminalService();
+    try {
+      const run = service.runCommand({
+        origin: "core",
+        projectId: "p1",
+        workspaceId: "w1",
+        cwd: process.cwd(),
+        title: "Environment check",
+        command: "printf '%s' \"$IS_PIWEB\"",
+      });
+
+      expect(await terminalExit(service, run.terminalId)).toContain("1");
+    } finally {
+      service.dispose();
+    }
+  });
+
   it("tracks dedicated terminal command runs through completion", async () => {
     const service = new TerminalService();
     try {

--- a/src/server/terminals/terminalService.ts
+++ b/src/server/terminals/terminalService.ts
@@ -163,7 +163,7 @@ export class TerminalService {
       cwd: record.cwd,
       cols: 100,
       rows: 30,
-      env: { ...process.env, TERM: "xterm-256color", IS_PIWEB: "1" },
+      env: { ...process.env, TERM: "xterm-256color", PI_WEB_TERMINAL: "1" },
     });
     this.attachPtyEvents(record);
     const info = toInfo(record);
@@ -196,7 +196,7 @@ export class TerminalService {
       cwd: options.cwd,
       cols: options.cols ?? 100,
       rows: options.rows ?? 30,
-      env: { ...process.env, TERM: "xterm-256color", IS_PIWEB: "1" },
+      env: { ...process.env, TERM: "xterm-256color", PI_WEB_TERMINAL: "1" },
     });
     const requestedName = options.name?.trim();
     const record: TerminalRecord = {

--- a/src/server/terminals/terminalService.ts
+++ b/src/server/terminals/terminalService.ts
@@ -163,7 +163,7 @@ export class TerminalService {
       cwd: record.cwd,
       cols: 100,
       rows: 30,
-      env: { ...process.env, TERM: "xterm-256color" },
+      env: { ...process.env, TERM: "xterm-256color", IS_PIWEB: "1" },
     });
     this.attachPtyEvents(record);
     const info = toInfo(record);
@@ -196,7 +196,7 @@ export class TerminalService {
       cwd: options.cwd,
       cols: options.cols ?? 100,
       rows: options.rows ?? 30,
-      env: { ...process.env, TERM: "xterm-256color" },
+      env: { ...process.env, TERM: "xterm-256color", IS_PIWEB: "1" },
     });
     const requestedName = options.name?.trim();
     const record: TerminalRecord = {


### PR DESCRIPTION
## Summary

Sets `PI_WEB_TERMINAL=1` for all shells opened in PI WEB terminals, including continued interactive shells.

This lets users run shell startup scripts only inside PI WEB terminals, for example:

```sh
if [ "$PI_WEB_TERMINAL" = "1" ]; then
  # Run PI WEB terminal setup here
fi
```

## Testing

- `PI_WEB_TERMINAL=1 npm test -- --run src/server/terminals/terminalService.test.ts`
- `npm run typecheck`
- `npx eslint src/server/terminals/terminalService.ts src/server/terminals/terminalService.test.ts`
- `npm run verify`
- `npm run build`
- `npm run pack:dry`
