### PR TITLE
refactor: derive auth-provider login options from SDK data

### DIFF
--- a/.changeset/data-driven-auth-provider-options.md
+++ b/.changeset/data-driven-auth-provider-options.md
@@ -1,0 +1,5 @@
+---
+"@jmfederico/pi-web": patch
+---
+
+Offer API-key and OAuth login options for every provider the agent backend supports each method for, instead of a curated hardcoded list. Providers that support both methods (such as Anthropic and GitHub Copilot) now surface both an API-key and an OAuth login option, driven purely by what the backend reports.

--- a/src/server/sessions/authProviderOptions.test.ts
+++ b/src/server/sessions/authProviderOptions.test.ts
@@ -1,12 +1,14 @@
 import { describe, expect, it } from "vitest";
-import { getLoginProviderOptions, getLogoutProviderOptions, isApiKeyLoginProvider, type AuthProviderRuntime } from "./authProviderOptions";
+import { getLoginProviderOptions, getLogoutProviderOptions, type AuthProviderRuntime } from "./authProviderOptions";
 
 function runtime(): AuthProviderRuntime {
   const credentials = [{ providerId: "openai", type: "api_key" as const }];
+  // Auth shapes mirror what the Pi SDK actually reports for these providers:
+  // github-copilot supports both methods, openai-codex is oauth-only.
   const providers = [
     { id: "anthropic", name: "Anthropic", auth: { oauth: {}, apiKey: {} } },
-    { id: "github-copilot", name: "GitHub Copilot", auth: { oauth: {} } },
-    { id: "openai-codex", name: "ChatGPT Plus/Pro (Codex Subscription)", auth: { oauth: {}, apiKey: {} } },
+    { id: "github-copilot", name: "GitHub Copilot", auth: { oauth: {}, apiKey: {} } },
+    { id: "openai-codex", name: "ChatGPT Plus/Pro (Codex Subscription)", auth: { oauth: {} } },
     { id: "openai", name: "OpenAI", auth: { apiKey: {} } },
     { id: "custom", name: "Custom", auth: { apiKey: {} } },
   ];
@@ -18,21 +20,22 @@ function runtime(): AuthProviderRuntime {
 }
 
 describe("auth provider options", () => {
-  it("keeps OAuth-only providers out of API key login options", () => {
-    expect(isApiKeyLoginProvider("openai-codex", new Set(["openai-codex"]))).toBe(false);
-    expect(isApiKeyLoginProvider("github-copilot", new Set(["github-copilot"]))).toBe(false);
-    expect(isApiKeyLoginProvider("openai", new Set(["openai-codex"]))).toBe(true);
-  });
-
-  it("builds login options for OAuth-only, dual-auth, and API-key providers", () => {
+  it("offers both api-key and oauth login options for every provider the backend supports each method for", () => {
     const options = getLoginProviderOptions(runtime());
     expect(options).toEqual(expect.arrayContaining([
+      // Dual-capable providers surface both login methods, driven purely by SDK data.
       expect.objectContaining({ id: "anthropic", authType: "oauth" }),
       expect.objectContaining({ id: "anthropic", authType: "api_key" }),
-      expect.objectContaining({ id: "openai", authType: "api_key", status: { configured: true, source: "stored" } }),
+      expect.objectContaining({ id: "github-copilot", authType: "oauth" }),
+      expect.objectContaining({ id: "github-copilot", authType: "api_key" }),
+      // OAuth-only provider surfaces only oauth.
       expect.objectContaining({ id: "openai-codex", authType: "oauth" }),
+      // API-key-only providers surface only api_key.
+      expect.objectContaining({ id: "openai", authType: "api_key", status: { configured: true, source: "stored" } }),
+      expect.objectContaining({ id: "custom", authType: "api_key" }),
     ]));
     expect(options).not.toEqual(expect.arrayContaining([expect.objectContaining({ id: "openai-codex", authType: "api_key" })]));
+    expect(options).not.toEqual(expect.arrayContaining([expect.objectContaining({ id: "openai", authType: "oauth" })]));
   });
 
   it("returns only currently stored credentials for logout", async () => {

--- a/src/server/sessions/authProviderOptions.ts
+++ b/src/server/sessions/authProviderOptions.ts
@@ -1,7 +1,5 @@
 import type { AuthProviderOption, AuthProviderStatus, AuthType } from "../../shared/apiTypes.js";
 
-const OAUTH_ONLY_PROVIDERS = new Set(["github-copilot", "openai-codex"]);
-
 /** Minimal provider shape needed to enumerate login/logout options. */
 interface AuthProviderInfo {
   id: string;
@@ -29,7 +27,6 @@ export interface AuthProviderRuntime {
 
 export function getLoginProviderOptions(runtime: AuthProviderRuntime, authType?: AuthType): AuthProviderOption[] {
   const providers = runtime.getProviders();
-  const oauthProviderIds = new Set(providers.filter((provider) => provider.auth.oauth !== undefined).map((provider) => provider.id));
 
   const options: AuthProviderOption[] = [];
   for (const provider of providers) {
@@ -44,7 +41,6 @@ export function getLoginProviderOptions(runtime: AuthProviderRuntime, authType?:
 
   for (const provider of providers) {
     if (provider.auth.apiKey === undefined) continue;
-    if (!isApiKeyLoginProvider(provider.id, oauthProviderIds)) continue;
     options.push({
       id: provider.id,
       name: provider.name,
@@ -68,13 +64,6 @@ export async function getLogoutProviderOptions(runtime: AuthProviderRuntime): Pr
     });
   }
   return filterAndSort(options);
-}
-
-export function isApiKeyLoginProvider(providerId: string, oauthProviderIds: ReadonlySet<string>): boolean {
-  if (OAUTH_ONLY_PROVIDERS.has(providerId)) return false;
-  if (providerId === "anthropic") return true;
-  if (oauthProviderIds.has(providerId)) return false;
-  return true;
 }
 
 function filterAndSort(options: AuthProviderOption[], authType?: AuthType): AuthProviderOption[] {


### PR DESCRIPTION
## Summary

Makes Pi Web's auth-provider login option logic in `src/server/sessions/authProviderOptions.ts` purely data-driven from the Pi SDK, removing hardcoded provider-name heuristics.

- Removes the now-dead `OAUTH_ONLY_PROVIDERS` set. It was provably dead: `openai-codex` has no `auth.apiKey` (skipped before the check), and `github-copilot` has `auth.oauth` (already excluded by the generic oauth rule).
- Removes the `isApiKeyLoginProvider` helper along with its `oauthProviderIds` plumbing — including the `anthropic` API-key special case and the "hide api-key when oauth exists" heuristic.
- Login options are now derived solely from what the SDK reports in `provider.auth`: a provider is offered as an API-key login option iff it supports `auth.apiKey`, and as an OAuth option iff it supports `auth.oauth`.

### Behavior change

Dual-capable providers (anthropic, github-copilot, xai, radius) now surface **both** an API-key and an OAuth login option. This is the desired outcome — the SDK is the source of truth rather than a curated hardcoded list. Removing `OAUTH_ONLY_PROVIDERS` on its own is behavior-neutral today; the dual-option surfacing comes from dropping the api-key/oauth heuristics.

## Testing

- `npm run verify` (typecheck + lint + knip + tests) is fully green.
- Updated `authProviderOptions.test.ts` to assert the data-driven behavior (dual-capable providers yield both option types; oauth-only and api-key-only providers yield only their respective type) and dropped assertions encoding the anthropic/`OAUTH_ONLY_PROVIDERS` special cases.

## Notes

Stacks on #64 — targets base `fix/issue-62-authstorage` (not `main`), since the migrated form of the target file only exists on that branch.