### PR TITLE
test: stabilize fileTreeService truncation test on slow filesystems

### DIFF
--- a/src/server/workspaces/fileTreeService.test.ts
+++ b/src/server/workspaces/fileTreeService.test.ts
@@ -81,6 +81,8 @@ describe("listWorkspaceTree", () => {
     await expect(listWorkspaceTree(root, "/tmp")).rejects.toThrow("Absolute paths are not allowed");
   });
 
+  // Writing MAX_ENTRIES + 1 files is inherently I/O-heavy; slow filesystems (notably
+  // Windows CI) can exceed Vitest's default 5s timeout, so give this case extra headroom.
   it("marks responses as truncated after the service entry limit", async () => {
     const root = await tempWorkspace();
     await Promise.all(Array.from({ length: 1001 }, (_, index) => writeFile(join(root, `${String(index).padStart(4, "0")}.txt`), "")));
@@ -89,7 +91,7 @@ describe("listWorkspaceTree", () => {
 
     expect(tree.entries).toHaveLength(1000);
     expect(tree.truncated).toBe(true);
-  });
+  }, 30_000);
 });
 
 async function trySymlink(target: string, path: string): Promise<boolean> {


### PR DESCRIPTION
## Root cause

`src/server/workspaces/fileTreeService.test.ts` recently went red on `windows-latest` (but passed on `ubuntu-latest`) with:

```
Error: Test timed out in 5000ms.
 ❯ src/server/workspaces/fileTreeService.test.ts:84:3
```

The `marks responses as truncated after the service entry limit` test writes `MAX_ENTRIES + 1` (1001) files via `Promise.all(...writeFile...)` and then calls `listWorkspaceTree`. This is inherently I/O-heavy, and on the slower Windows CI filesystem the setup + scan exceeds Vitest's default 5000ms timeout. It is a flaky/slow-filesystem timeout, not a logic bug — the assertion (truncation at the 1000-entry `MAX_ENTRIES` limit) is correct and unchanged.

## Fix

Raise the per-test timeout to 30s for this single I/O-heavy test (via the `it(..., 30_000)` timeout argument), and add a comment explaining why.

### Why this over alternatives

- **Injectable `MAX_ENTRIES`**: rejected. Lowering the file count would require adding a limit parameter to the production `listWorkspaceTree` API purely to serve the test. There is no real production need to configure the limit, so this would be a test-only hack disguised as an API — the task guidance explicitly says to avoid that.
- **Per-test timeout bump**: chosen. It is the most targeted, honest fix for a genuinely I/O-bound test. It keeps the truncation behavior fully verified (still writes 1001 files, still asserts 1000 entries + `truncated: true`) without touching production code.

## Verification

`npm run verify` (typecheck + lint + knip + tests) is fully green — 188 test files, 1395 passed.

No changeset: this is a test-only internal change with no user-observable behavior change.