### PR TITLE
fix(terminals): load interactive login profiles

### DIFF
--- a/.changeset/load-interactive-shell-profiles.md
+++ b/.changeset/load-interactive-shell-profiles.md
@@ -1,0 +1,5 @@
+---
+"@jmfederico/pi-web": patch
+---
+
+Load login shell profiles in new and continued interactive terminals so PATH-managed commands are available.

--- a/src/server/terminals/terminalService.test.ts
+++ b/src/server/terminals/terminalService.test.ts
@@ -1,8 +1,26 @@
+import { chmod, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import type { RealtimeEvent, TerminalInfo } from "../../shared/apiTypes.js";
 import type { WorkspaceActivityService } from "../activity/workspaceActivityService.js";
 import { SessionEventHub } from "../realtime/sessionEventHub.js";
-import { TerminalService } from "./terminalService";
+import { interactiveShellArgs, TerminalService } from "./terminalService";
+
+describe("interactive shell arguments", () => {
+  it.each([
+    { shell: "bash", expected: ["-l"] },
+    { shell: "/usr/local/bin/zsh", expected: ["-l"] },
+    { shell: "/opt/homebrew/bin/fish", expected: ["-l"] },
+    { shell: String.raw`C:\Program Files\Git\bin\bash.exe`, expected: ["-l"] },
+    { shell: "/bin/dash", expected: [] },
+    { shell: "pwsh", expected: [] },
+    { shell: "powershell.exe", expected: [] },
+    { shell: "cmd.exe", expected: [] },
+  ])("uses login mode only for a supported shell: $shell", ({ shell, expected }) => {
+    expect(interactiveShellArgs(shell)).toEqual(expected);
+  });
+});
 
 // TerminalService spawns a POSIX shell (/bin/bash with -lc and commands like
 // printf/true/exit). The terminal feature is not supported on native Windows,
@@ -20,6 +38,47 @@ describe.skipIf(process.platform === "win32")("TerminalService command runs", ()
     } finally {
       service.dispose();
     }
+  });
+
+  it("loads login-profile PATH entries in new interactive terminals", async () => {
+    await withBashLoginProfile(async () => {
+      const service = new TerminalService();
+      try {
+        const terminal = service.create({ cwd: process.cwd() });
+        const exit = terminalExit(service, terminal.id);
+
+        service.write(terminal.id, `${LOGIN_PROFILE_COMMAND}\nexit\n`);
+
+        expect(await exit).toContain(LOGIN_PROFILE_OUTPUT);
+      } finally {
+        service.dispose();
+      }
+    });
+  });
+
+  it("loads login-profile PATH entries in continued interactive terminals", async () => {
+    await withBashLoginProfile(async () => {
+      const service = new TerminalService();
+      try {
+        const run = service.runCommand({
+          origin: "core",
+          projectId: "p1",
+          workspaceId: "w1",
+          cwd: process.cwd(),
+          title: "Done command",
+          command: "true",
+        });
+        await terminalExit(service, run.terminalId);
+
+        service.continue(run.terminalId);
+        const exit = terminalExit(service, run.terminalId);
+        service.write(run.terminalId, `${LOGIN_PROFILE_COMMAND}\nexit\n`);
+
+        expect(await exit).toContain(LOGIN_PROFILE_OUTPUT);
+      } finally {
+        service.dispose();
+      }
+    });
   });
 
   describe("PI_WEB_TERMINAL propagation", () => {
@@ -221,6 +280,36 @@ function requireTerminal(service: TerminalService, terminalId: string): Terminal
   const terminal = service.get(terminalId);
   if (terminal === undefined) throw new Error(`Expected terminal ${terminalId} to exist`);
   return terminal;
+}
+
+const LOGIN_PROFILE_COMMAND = "pi-web-test-login-profile-command";
+const LOGIN_PROFILE_OUTPUT = "__PI_WEB_LOGIN_PROFILE_PATH_COMMAND__";
+
+async function withBashLoginProfile(run: () => Promise<void>): Promise<void> {
+  const home = await mkdtemp(join(tmpdir(), "pi-web-terminal-home-"));
+  const profileBin = join(home, "profile-bin");
+  await mkdir(profileBin);
+  const commandPath = join(profileBin, LOGIN_PROFILE_COMMAND);
+  await writeFile(commandPath, `#!/bin/sh\nprintf '%s\\n' '${LOGIN_PROFILE_OUTPUT}'\n`);
+  await chmod(commandPath, 0o755);
+  await writeFile(join(home, ".bash_profile"), `export PATH="$HOME/profile-bin:$PATH"\n`);
+
+  const originalHome = process.env["HOME"];
+  const originalShell = process.env["SHELL"];
+  process.env["HOME"] = home;
+  process.env["SHELL"] = "/bin/bash";
+  try {
+    await run();
+  } finally {
+    restoreEnv("HOME", originalHome);
+    restoreEnv("SHELL", originalShell);
+    await rm(home, { recursive: true, force: true });
+  }
+}
+
+function restoreEnv(key: "HOME" | "SHELL", value: string | undefined): void {
+  if (value === undefined) Reflect.deleteProperty(process.env, key);
+  else process.env[key] = value;
 }
 
 function terminalExit(service: TerminalService, terminalId: string): Promise<string> {

--- a/src/server/terminals/terminalService.ts
+++ b/src/server/terminals/terminalService.ts
@@ -54,7 +54,8 @@ export class TerminalService {
   }
 
   create(options: { cwd: string; name?: string; cols?: number; rows?: number }): TerminalInfo {
-    return this.createTerminal({ ...options, shellArgs: [] });
+    const shell = process.env["SHELL"] ?? "/bin/bash";
+    return this.createTerminal({ ...options, shellArgs: interactiveShellArgs(shell) });
   }
 
   runCommand(options: RunTerminalCommandOptions): TerminalCommandRun {
@@ -158,7 +159,7 @@ export class TerminalService {
     record.buffer = trimReplayBuffer(record.buffer + marker);
     record.events.emit("output", marker);
     const shell = process.env["SHELL"] ?? "/bin/bash";
-    record.pty = pty.spawn(shell, [], {
+    record.pty = pty.spawn(shell, interactiveShellArgs(shell), {
       name: "xterm-256color",
       cwd: record.cwd,
       cols: 100,
@@ -273,6 +274,12 @@ function toInfo(record: TerminalRecord): TerminalInfo {
 function trimReplayBuffer(buffer: string): string {
   if (buffer.length <= MAX_REPLAY_BUFFER) return buffer;
   return buffer.slice(buffer.length - MAX_REPLAY_BUFFER);
+}
+
+export function interactiveShellArgs(shell: string): string[] {
+  const executable = shell.split(/[\\/]/).at(-1)?.toLowerCase().replace(/^-/, "").replace(/\.exe$/, "");
+  // Preserve the existing invocation for arbitrary SHELL values rather than guessing at an unsupported login flag.
+  return executable === "bash" || executable === "zsh" || executable === "fish" ? ["-l"] : [];
 }
 
 function commandRunShellScript(command: string): string {


### PR DESCRIPTION
Fixes #67.

## Problem

New interactive terminal tabs and command-run terminals continued into interactive mode spawned the configured shell without arguments. Bash, zsh, and fish therefore ran as non-login shells, so PATH entries initialized only by login profiles were unavailable even though dedicated command runs already used login mode.

A controlled Bash reproduction on current `main` put a unique executable on PATH from `~/.bash_profile`: both interactive spawn paths reported `command not found`.

## Fix

- Start new and continued interactive Bash, zsh, and fish shells with the shared `-l` login flag.
- Recognize bare, POSIX-path, and Windows-path shell executables while preserving the existing no-argument invocation for PowerShell, cmd, and unknown shells instead of guessing at an unsupported flag.
- Add behavior-focused regressions whose temporary Bash login profile adds an executable to PATH, then verify that both interactive spawn paths can run it.
- Add a patch Changeset for the user-visible fix.

This stays within the existing shell-selection boundary and does not broaden PI WEB's native-Windows terminal support contract.

## Verification

- `npm test -- --run src/server/terminals/terminalService.test.ts` — **1 file, 16 passed**
- `npm run verify` — typecheck, ESLint, Knip, and **189 test files; 1,452 passed, 2 skipped**
- `npm run build` — passed
- `npm run pack:dry` — passed; **238 files, 1.7 MB**
- `npm run changelog:status` — valid patch bump
- Controlled Bash profile reproduction — profile-only command changed from `command not found` on `main` to successful execution on this branch

## Operational note

`TerminalService` is loaded by `pi-web-sessiond`. After deploying this change, manually restart the session daemon before testing newly created or continued terminal shells.
