### PR TITLE
fix(sessions): surface extension command notifications

### DIFF
--- a/.changeset/show-extension-command-notifications.md
+++ b/.changeset/show-extension-command-notifications.md
@@ -1,0 +1,5 @@
+---
+"@jmfederico/pi-web": patch
+---
+
+Show notifications emitted by Pi extension slash commands in the web chat.

--- a/src/server/sessions/piSessionService.lifecycle.test.ts
+++ b/src/server/sessions/piSessionService.lifecycle.test.ts
@@ -319,6 +319,46 @@ describe("PiSessionService lifecycle, listing, and reload", () => {
     await service.dispose();
   });
 
+  it("surfaces notifications when an extension command shares a bare name with a skill", async () => {
+    const hub = new CapturingSessionEventHub();
+    const fake = fakeRuntime("extension-command-session", {
+      resourceLoader: { getSkills: () => ({ skills: [{ name: "ctx-stats" }] }) },
+    });
+    let extensionNotify: ((message: string, type?: "info" | "warning" | "error") => void) | undefined;
+    let extensionMode: string | undefined;
+    fake.session.extensionRunner.getRegisteredCommands = () => [{ invocationName: "ctx-stats" }];
+    fake.session.bindExtensions = (bindings) => {
+      const uiContext = bindings.uiContext;
+      extensionNotify = uiContext === undefined
+        ? undefined
+        : (message, type) => { uiContext.notify(message, type); };
+      extensionMode = bindings.mode;
+      return Promise.resolve();
+    };
+    fake.session.prompt = (text) => {
+      if (text === "/ctx-stats") extensionNotify?.("context-mode stats", "info");
+      return Promise.resolve();
+    };
+    const service = new PiSessionService(hub, {
+      agentDir: TEST_AGENT_DIR,
+      modelRuntime: testModelRuntime,
+      createAgentRuntime: runtimeCreator(fake.runtime),
+      sessionManager: sessionGateway([]),
+      heartbeatIntervalMs: 60_000,
+    });
+
+    await service.start("/workspace");
+    await expect(service.runCommand(sessionRef("extension-command-session"), "/ctx-stats")).resolves.toEqual({ type: "done" });
+
+    expect(extensionMode).toBe("rpc");
+    expect(hub.sessionEvents).toContainEqual({
+      sessionId: "extension-command-session",
+      event: { type: "command.output", level: "info", message: "context-mode stats" },
+    });
+
+    await service.dispose();
+  });
+
   it("clears stale active activity once a previously active session becomes idle", async () => {
     vi.useFakeTimers();
     let service: PiSessionService | undefined;

--- a/src/server/sessions/piSessionService.testSupport.ts
+++ b/src/server/sessions/piSessionService.testSupport.ts
@@ -1,4 +1,4 @@
-import { ModelRuntime } from "@earendil-works/pi-coding-agent";
+import { ModelRuntime, type ExtensionUIContext } from "@earendil-works/pi-coding-agent";
 import { InMemoryCredentialStore, type Credential, type CredentialStore } from "@earendil-works/pi-ai";
 import type { GlobalSessionEvent, SessionUiEvent } from "../../shared/apiTypes.js";
 import { SessionEventHub } from "../realtime/sessionEventHub.js";
@@ -89,6 +89,37 @@ export function createTestModelRuntime(credentials: CredentialStore = new InMemo
  */
 export const testModelRuntime = await createTestModelRuntime();
 
+const testExtensionUiContext: ExtensionUIContext = {
+  select: () => Promise.resolve(undefined),
+  confirm: () => Promise.resolve(false),
+  input: () => Promise.resolve(undefined),
+  notify() { /* no-op */ },
+  onTerminalInput: () => () => undefined,
+  setStatus() { /* no-op */ },
+  setWorkingMessage() { /* no-op */ },
+  setWorkingVisible() { /* no-op */ },
+  setWorkingIndicator() { /* no-op */ },
+  setHiddenThinkingLabel() { /* no-op */ },
+  setWidget() { /* no-op */ },
+  setFooter() { /* no-op */ },
+  setHeader() { /* no-op */ },
+  setTitle() { /* no-op */ },
+  custom: () => Promise.reject(new Error("Custom extension UI is unavailable in tests")),
+  pasteToEditor() { /* no-op */ },
+  setEditorText() { /* no-op */ },
+  getEditorText: () => "",
+  editor: () => Promise.resolve(undefined),
+  addAutocompleteProvider() { /* no-op */ },
+  setEditorComponent() { /* no-op */ },
+  getEditorComponent: () => undefined,
+  get theme(): ExtensionUIContext["theme"] { throw new Error("Extension UI theme is unavailable in tests"); },
+  getAllThemes: () => [],
+  getTheme: () => undefined,
+  setTheme: () => ({ success: false, error: "Extension UI is unavailable in tests" }),
+  getToolsExpanded: () => false,
+  setToolsExpanded() { /* no-op */ },
+};
+
 export function testModel(): NonNullable<PiAgentSession["model"]> {
   const model = testModelRuntime.getModel(TEST_MODEL_PROVIDER, TEST_MODEL_ID);
   if (model === undefined) throw new Error("test model not found");
@@ -117,7 +148,10 @@ export function fakeRuntime(sessionId = "session-1", patch: Partial<TestSession>
     settingsManager: { getWarnings: () => ({}), setWarnings: () => undefined },
     modelRuntime: testModelRuntime,
     scopedModels: [],
-    extensionRunner: { getRegisteredCommands: () => [] },
+    extensionRunner: {
+      getRegisteredCommands: () => [],
+      getUIContext: () => testExtensionUiContext,
+    },
     promptTemplates: [],
     resourceLoader: { getSkills: () => ({ skills: [] }) },
     subscribe: (listener: (event: unknown) => void) => {

--- a/src/server/sessions/piSessionService.ts
+++ b/src/server/sessions/piSessionService.ts
@@ -15,6 +15,7 @@ import {
   type AgentSessionServices,
   type CreateAgentSessionRuntimeFactory,
   type EditToolDetails,
+  type ExtensionUIContext,
   type ModelRuntime,
   type ResourceDiagnostic,
 } from "@earendil-works/pi-coding-agent";
@@ -204,6 +205,8 @@ interface PiExtensionError {
 }
 
 interface PiExtensionBindings {
+  uiContext?: ExtensionUIContext;
+  mode?: "rpc";
   onError?: (error: PiExtensionError) => void;
 }
 
@@ -239,7 +242,10 @@ export interface PiAgentSession {
   isCompacting: boolean;
   isBashRunning: boolean;
   pendingMessageCount: number;
-  extensionRunner: { getRegisteredCommands(): readonly { invocationName: string; description?: string }[] };
+  extensionRunner: {
+    getRegisteredCommands(): readonly { invocationName: string; description?: string }[];
+    getUIContext(): ExtensionUIContext;
+  };
   promptTemplates: readonly { name: string; description?: string }[];
   resourceLoader: { getSkills(): { skills: readonly { name: string; description?: string }[] } };
   subscribe(listener: (event: unknown) => void): () => void;
@@ -1903,7 +1909,27 @@ export class PiSessionService implements SessionRouteService {
   }
 
   private async bindSessionExtensions(session: PiAgentSession): Promise<void> {
+    const baseUiContext = session.extensionRunner.getUIContext();
+    const notify: ExtensionUIContext["notify"] = (message, type) => {
+      this.events.publish(session.sessionId, {
+        type: "command.output",
+        level: type === "error" ? "error" : "info",
+        message,
+      });
+    };
+    // PI WEB is a remote UI host, but currently only extension notifications
+    // cross this boundary. Delegate every other UI method to Pi's headless
+    // defaults so unsupported dialogs cancel safely instead of hanging.
+    const uiContext = new Proxy(baseUiContext, {
+      get(target, property, receiver): unknown {
+        if (property === "notify") return notify;
+        const value: unknown = Reflect.get(target, property, receiver);
+        return value;
+      },
+    });
     await session.bindExtensions({
+      uiContext,
+      mode: "rpc",
       onError: (error) => {
         const message = `${error.extensionPath}: ${error.error}`;
         this.publishActivity(session, "extension error", "error", message);


### PR DESCRIPTION
## Summary

- bind Pi sessions to an RPC-style extension UI context
- surface `ctx.ui.notify()` calls as session-scoped chat output while preserving Pi's safe headless defaults for unsupported UI methods
- cover the extension-command/skill name collision reported with context-mode
- add a patch Changeset

## Root cause and rationale

The reported symptom is current, but the router/autocomplete diagnosis is not. PI WEB already lists and inserts skills canonically as `/skill:<name>`. `context-mode@1.0.169` registers both a `ctx-stats` skill and an exact `/ctx-stats` extension command, and Pi intentionally resolves extension commands before skill expansion.

The exact extension command was therefore accepted and run. It then attempted to report its result through `ctx.ui.notify()`. PI WEB had bound only extension error handling, leaving Pi's no-op print-mode UI (`ctx.hasUI === false`); context-mode's fallback command return value is not part of Pi's command-handler output contract, so the accepted command produced no visible output.

This change fixes the host boundary rather than introducing a bare-skill alias that could shadow exact extension commands or prompt templates. Extension notifications now flow through the existing `command.output` session event and render in chat. Other extension UI methods retain Pi's headless defaults, so unsupported dialogs cancel rather than hang.

## Verification

- `npm test -- --run src/server/sessions/piSessionService.lifecycle.test.ts src/server/sessions/sessionCommandService.test.ts` — 2 files, 31 tests passed
- `npm run verify` — typecheck, lint, Knip, 189 test files; 1,443 passed and 2 skipped
- `npm run build` — passed (existing Vite chunk-size warning only)
- isolated reproduction with `context-mode@1.0.169` confirmed current main registered both `ctx-stats` paths but emitted no event with `ctx.hasUI === false`; the new binding produced the full stats notification in RPC mode

## Operations

This changes session-runtime extension binding code. A running `pi-web-sessiond.service` must be restarted manually after deploying the change.

Fixes #68
