### PR TITLE
Support Jujutsu (git compatible alternative) workspaces

### DIFF
--- a/.changeset/add-jj-workspaces.md
+++ b/.changeset/add-jj-workspaces.md
@@ -1,0 +1,6 @@
+---
+"@jmfederico/pi-web": patch
+---
+
+Discover, select, and safely forget Jujutsu workspaces alongside Git worktrees,
+with Jujutsu status and diffs in the workspace Changes panel.

--- a/docs/faq.html
+++ b/docs/faq.html
@@ -92,6 +92,7 @@
             <a href="#is-this-linux-only">What platforms are supported?</a>
             <a href="#is-pi-web-a-web-ui">Is PI WEB a Pi web UI?</a>
             <a href="#tools-are-not-found">Tools are failing / node not found</a>
+            <a href="#jj-not-found">Jujutsu workspaces report jj not found</a>
             <a href="#doctor-fails">What does doctor check?</a>
             <a href="#nvm-fnm-asdf">nvm, fnm, or asdf issues</a>
             <a href="#node-pty-native-module">node-pty native module is missing</a>
@@ -153,6 +154,19 @@
                 Avoid relying only on prompt hooks, shell integrations that rewrite PATH while rendering a prompt, or
                 interactive-only shell files for tools needed by services. Version-manager shims are usually the most
                 reliable option for service environments.
+              </p>
+            </article>
+
+            <article id="jj-not-found" class="faq-item">
+              <h2>Jujutsu workspaces report <code>jj</code> not found</h2>
+              <p>
+                PI WEB discovers a Jujutsu repository from its <code>.jj</code> metadata, then runs <code>jj</code> for
+                workspace status and diffs. Install a compatible Jujutsu CLI and make sure <code>jj</code> is available
+                to both the web/API service and session daemon through the service login-shell <code>PATH</code>.
+              </p>
+              <p>
+                Check the service login shell with <code>"$SHELL" -lc 'command -v jj'</code> and inspect
+                <code>pi-web logs</code>. After changing <code>PATH</code>, restart both PI WEB services.
               </p>
             </article>
 

--- a/docs/install.html
+++ b/docs/install.html
@@ -109,6 +109,7 @@
                 <li><strong>Node.js 22.19.0 or newer</strong> and npm.</li>
                 <li><strong>Pi Coding Agent <code>&gt;=0.82.1 &lt;0.83</code></strong> installed/configured so the <code>pi</code> command works for your user.</li>
                 <li>A shell login environment that exposes Node, npm, Pi, git, and any tools your agents need.</li>
+                <li>Optional: <code>jj</code> on the service PATH to discover and inspect Jujutsu workspaces.</li>
                 <li>For the automatic installer: a supported per-user service manager.</li>
               </ul>
               <div class="callout warning">

--- a/pi-web-plugins/info/pi-web-plugin.ts
+++ b/pi-web-plugins/info/pi-web-plugin.ts
@@ -21,7 +21,7 @@ const plugin: PiWebPlugin = {
         {
           id: "workspace.kind-label",
           order: 100,
-          items: (context) => [{ type: "text", text: context.workspace.isGitRepo ? "git" : "folder", title: context.workspace.path }],
+          items: (context) => [{ type: "text", text: context.workspace.vcs ?? (context.workspace.isGitRepo ? "git" : "folder"), title: context.workspace.path }],
         },
       ],
       workspacePanels: [

--- a/src/client/src/api/parsers.test.ts
+++ b/src/client/src/api/parsers.test.ts
@@ -493,6 +493,8 @@ describe("API parsers", () => {
       path: "/repo",
       label: "main",
       branch: "main",
+      vcs: "jj",
+      vcsWorkspaceName: "default",
       isMain: true,
       isGitRepo: true,
       isGitWorktree: false,
@@ -503,11 +505,26 @@ describe("API parsers", () => {
       path: "/repo",
       label: "main",
       branch: "main",
+      vcs: "jj",
+      vcsWorkspaceName: "default",
       isMain: true,
       isGitRepo: true,
       isGitWorktree: false,
       effectiveConfig: { uploads: { defaultFolder: "manual/uploads" } },
     });
+  });
+
+  it("rejects unknown workspace VCS values", () => {
+    expect(() => parseWorkspace({
+      id: "w1",
+      projectId: "p1",
+      path: "/repo",
+      label: "main",
+      vcs: "svn",
+      isMain: true,
+      isGitRepo: false,
+      isGitWorktree: false,
+    })).toThrow("Invalid workspace VCS");
   });
 
   it("accepts legacy workspace responses without effective config", () => {
@@ -537,6 +554,17 @@ describe("API parsers", () => {
     })).toEqual({
       generatedAt: "now",
       workspaces: [{ cwd: "/repo", hasSessionActivity: true, hasTerminalActivity: false, updatedAt: "later" }],
+    });
+  });
+
+  it("parses Jujutsu changes responses", () => {
+    expect(parseGitStatusResponse({ isGitRepo: false, vcs: "jj", hash: "h", branch: "abcdefgh", files: [] })).toEqual({
+      isGitRepo: false,
+      vcs: "jj",
+      hash: "h",
+      branch: "abcdefgh",
+      files: [],
+      submodules: [],
     });
   });
 

--- a/src/client/src/api/parsers.ts
+++ b/src/client/src/api/parsers.ts
@@ -134,17 +134,26 @@ export function parseProject(value: unknown): Project {
 export function parseWorkspace(value: unknown): Workspace {
   const record = requireRecord(value);
   const branch = optionalString(record, "branch");
+  const vcs = parseVcs(record["vcs"]);
+  const vcsWorkspaceName = optionalString(record, "vcsWorkspaceName");
   return {
     id: requireString(record, "id"),
     projectId: requireString(record, "projectId"),
     path: requireString(record, "path"),
     label: requireString(record, "label"),
     ...(branch === undefined ? {} : { branch }),
+    ...(vcs === undefined ? {} : { vcs }),
+    ...(vcsWorkspaceName === undefined ? {} : { vcsWorkspaceName }),
     isMain: requireBoolean(record, "isMain"),
     isGitRepo: requireBoolean(record, "isGitRepo"),
     isGitWorktree: requireBoolean(record, "isGitWorktree"),
     ...optionalField("effectiveConfig", optionalWorkspaceEffectiveConfig(record["effectiveConfig"])),
   };
+}
+
+function parseVcs(value: unknown): Workspace["vcs"] {
+  if (value === undefined || value === "git" || value === "jj") return value;
+  throw new Error("Invalid workspace VCS");
 }
 
 function optionalWorkspaceEffectiveConfig(value: unknown): Workspace["effectiveConfig"] | undefined {
@@ -868,7 +877,7 @@ function optionalFileMediaType(value: unknown): FileContentResponse["mediaType"]
 
 export function parseGitStatusResponse(value: unknown): GitStatusResponse {
   const record = requireRecord(value);
-  return { isGitRepo: requireBoolean(record, "isGitRepo"), hash: requireString(record, "hash"), ...optionalField("branch", optionalString(record, "branch")), ...optionalField("upstream", optionalString(record, "upstream")), ...optionalField("ahead", optionalNumber(record, "ahead")), ...optionalField("behind", optionalNumber(record, "behind")), files: arrayOf(parseGitStatusFile)(record["files"]), submodules: record["submodules"] === undefined ? [] : arrayOfString(record["submodules"], "submodules") };
+  return { isGitRepo: requireBoolean(record, "isGitRepo"), ...optionalField("vcs", parseVcs(record["vcs"])), hash: requireString(record, "hash"), ...optionalField("branch", optionalString(record, "branch")), ...optionalField("upstream", optionalString(record, "upstream")), ...optionalField("ahead", optionalNumber(record, "ahead")), ...optionalField("behind", optionalNumber(record, "behind")), files: arrayOf(parseGitStatusFile)(record["files"]), submodules: record["submodules"] === undefined ? [] : arrayOfString(record["submodules"], "submodules") };
 }
 
 function parseGitStatusFile(value: unknown): GitStatusFile {
@@ -895,7 +904,7 @@ function parseGitFileState(value: unknown): GitFileState {
 
 export function parseGitDiffResponse(value: unknown): GitDiffResponse {
   const record = requireRecord(value);
-  return { ...optionalField("path", optionalString(record, "path")), staged: requireBoolean(record, "staged"), hash: requireString(record, "hash"), diff: requireString(record, "diff"), truncated: requireBoolean(record, "truncated") };
+  return { ...optionalField("path", optionalString(record, "path")), ...optionalField("vcs", parseVcs(record["vcs"])), staged: requireBoolean(record, "staged"), hash: requireString(record, "hash"), diff: requireString(record, "diff"), truncated: requireBoolean(record, "truncated") };
 }
 
 export function parseTerminalInfo(value: unknown): TerminalInfo {

--- a/src/client/src/components/PiWebApp.ts
+++ b/src/client/src/components/PiWebApp.ts
@@ -5,6 +5,7 @@ import type { AppAction } from "../actions";
 import { initialAppState, type AppState } from "../appState";
 import { isSessionActive } from "../../../shared/activity";
 import { PI_WEB_CAPABILITIES, supportsPiWebCapability } from "../../../shared/capabilities";
+import { isDeletableWorkspace } from "../../../shared/workspaces";
 import { ActivityController } from "../controllers/activityController";
 import { AuthController } from "../controllers/authController";
 import { FileExplorerController } from "../controllers/fileExplorerController";
@@ -15,7 +16,7 @@ import { ProjectActivityOwnershipCoordinator } from "../controllers/projectActiv
 import { PiWebStatusController } from "../controllers/piWebStatusController";
 import { SessionController } from "../controllers/sessionController";
 import { SessionNotificationController } from "../controllers/sessionNotificationController";
-import { WorkspaceController, canDeleteWorkspace } from "../controllers/workspaceController";
+import { WorkspaceController } from "../controllers/workspaceController";
 import { emptyMachineNavigationSnapshot, machineNavigationSnapshotFromState, routeFromMachineNavigationSnapshot, SessionStorageMachineNavigationMemory, type MachineNavigationSnapshot, type WorkspaceRouteSurface } from "../controllers/machineNavigationMemory";
 import { SessionStorageSessionSelectionMemory } from "../controllers/sessionSelection";
 import { SessionStorageTerminalSelectionMemory } from "../controllers/terminalSelection";
@@ -1811,13 +1812,16 @@ export class PiWebApp extends LitElement {
 
   private async deleteWorkspace(workspace = this.state.selectedWorkspace): Promise<void> {
     if (workspace === undefined) return;
-    if (!canDeleteWorkspace(workspace)) {
-      this.setState({ error: "Only secondary Git worktrees can be deleted" });
+    if (!isDeletableWorkspace(workspace)) {
+      this.setState({ error: "Only secondary Git worktrees or Jujutsu workspaces can be deleted" });
       return;
     }
     if (isWorkspaceDeletionPending(this.state, workspace)) return;
     const label = workspace.branch ?? workspace.label;
-    const confirmed = confirm(`Delete workspace ${label}?\n\nThis will run git worktree remove and delete:\n${workspace.path}\n\nThe Git branch will not be deleted.`);
+    const detail = workspace.vcs === "jj"
+      ? `This will forget the Jujutsu workspace. Its files will remain on disk at:\n${workspace.path}\n\nThe workspace commit will remain in the repository.`
+      : `This will run git worktree remove and delete:\n${workspace.path}\n\nThe Git branch will not be deleted.`;
+    const confirmed = confirm(`Delete workspace ${label}?\n\n${detail}`);
     if (!confirmed) return;
 
     const machineId = selectedMachineId(this.state);
@@ -2170,6 +2174,7 @@ export class PiWebApp extends LitElement {
       activities: this.state.sessionActivities,
       sending: this.state.sendingPrompts,
     });
+    const workspacePanelContext = this.state.selectedWorkspace === undefined ? undefined : this.createWorkspacePanelContext(this.state.selectedWorkspace);
     return [
       {
         id: "navigation",
@@ -2183,7 +2188,7 @@ export class PiWebApp extends LitElement {
         const icon = panel.icon ?? this.mobilePanelIcon(panel);
         return {
           id: panel.id,
-          label: panel.title,
+          label: workspacePanelContext === undefined ? panel.title : panel.titleFor?.(workspacePanelContext) ?? panel.title,
           ...(icon === undefined ? {} : { icon }),
           badge: this.mobilePanelBadge(panel),
         };

--- a/src/client/src/components/WorkspaceList.ts
+++ b/src/client/src/components/WorkspaceList.ts
@@ -1,5 +1,6 @@
 import { LitElement, html, type PropertyValues, type TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
+import { isDeletableWorkspace } from "../../../shared/workspaces";
 import type { Workspace, WorkspaceActivity } from "../api";
 import type { WorkspaceLabelItem } from "../plugins/types";
 import { workspaceActivityFor, workspaceActivityIndicator } from "../workspaceActivity";
@@ -135,7 +136,7 @@ export class WorkspaceList extends LitElement implements KeyboardNavigableSectio
   }
 
   private renderWorkspaceActions(workspace: Workspace): TemplateResult | undefined {
-    if (!canDeleteWorkspace(workspace)) return undefined;
+    if (!isDeletableWorkspace(workspace)) return undefined;
     const deleting = this.isDeleting(workspace);
     return html`
       <div class="workspace-menu-actions">
@@ -208,10 +209,6 @@ export class WorkspaceList extends LitElement implements KeyboardNavigableSectio
 
 function workspacePrimaryLabel(workspace: Workspace): string {
   return `${workspace.branch ?? workspace.label}${workspace.isMain ? " · main" : ""}`;
-}
-
-function canDeleteWorkspace(workspace: Workspace): boolean {
-  return workspace.isGitWorktree && !workspace.isMain;
 }
 
 function workspaceMenuId(workspaceId: string): string {

--- a/src/client/src/components/WorkspacePanel.ts
+++ b/src/client/src/components/WorkspacePanel.ts
@@ -69,10 +69,11 @@ export class WorkspacePanel extends LitElement {
                 ${visiblePanels.map((panel) => {
                   const selected = selectedPanel?.id === panel.id;
                   const badge = panel.badge?.(context);
-                  const ariaLabel = this.panelTabAriaLabel(panel, badge);
+                  const title = panel.titleFor?.(context) ?? panel.title;
+                  const ariaLabel = this.panelTabAriaLabel(title, badge);
                   return html`
                     <button class=${this.panelTabClass(panel, selected)} title=${ariaLabel} aria-label=${ariaLabel} aria-pressed=${String(selected)} @click=${() => { this.onSelectTool(panel.id); }}>
-                      ${this.renderPanelTabContent(panel, badge)}
+                      ${this.renderPanelTabContent(panel, title, badge)}
                     </button>
                   `;
                 })}
@@ -99,16 +100,16 @@ export class WorkspacePanel extends LitElement {
     ].join(" ");
   }
 
-  private panelTabAriaLabel(panel: QualifiedWorkspacePanelContribution, badge: WorkspacePanelBadge): string {
-    if (typeof badge !== "string" && typeof badge !== "number") return panel.title;
+  private panelTabAriaLabel(title: string, badge: WorkspacePanelBadge): string {
+    if (typeof badge !== "string" && typeof badge !== "number") return title;
     const trimmedBadge = String(badge).trim();
-    return trimmedBadge === "" ? panel.title : `${panel.title}, ${trimmedBadge}`;
+    return trimmedBadge === "" ? title : `${title}, ${trimmedBadge}`;
   }
 
-  private renderPanelTabContent(panel: QualifiedWorkspacePanelContribution, badge: WorkspacePanelBadge): TemplateResult {
+  private renderPanelTabContent(panel: QualifiedWorkspacePanelContribution, title: string, badge: WorkspacePanelBadge): TemplateResult {
     return html`
       ${panel.icon === undefined ? null : html`<span class="tab-custom-icon" aria-hidden="true">${panel.icon}</span>`}
-      <span class="tab-label">${panel.title}</span>
+      <span class="tab-label">${title}</span>
       ${this.isEmptyBadge(badge) ? null : html`<span class="tab-badge">${badge}</span>`}
     `;
   }

--- a/src/client/src/controllers/workspaceController.ts
+++ b/src/client/src/controllers/workspaceController.ts
@@ -153,10 +153,6 @@ export class WorkspaceController {
   }
 }
 
-export function canDeleteWorkspace(workspace: Workspace | undefined): boolean {
-  return workspace !== undefined && workspace.isGitWorktree && !workspace.isMain;
-}
-
 function selectFallbackWorkspace(workspaces: Workspace[]): Workspace | undefined {
   return workspaces.find((workspace) => workspace.isMain) ?? workspaces[0];
 }

--- a/src/client/src/plugins/core/actions.ts
+++ b/src/client/src/plugins/core/actions.ts
@@ -1,5 +1,6 @@
 import { isSessionActive } from "../../../../shared/activity";
 import { PI_WEB_CAPABILITIES, supportsPiWebCapability, type PiWebCapability } from "../../../../shared/capabilities";
+import { isDeletableWorkspace } from "../../../../shared/workspaces";
 import type { AppState } from "../../appState";
 import { selectedMachineId } from "../../controllers/types";
 import { isArchivableSessionInfo, isTransientNewSessionInfo, sessionPersistenceOptionsForRuntime } from "../../sessionPersistence";
@@ -113,10 +114,10 @@ export function createCoreActions(): PluginAction[] {
     },
     {
       id: "view.git",
-      title: "Go to Git",
+      title: "Go to Changes",
       shortcut: "mod+3",
       group: "Navigation",
-      enabled: hasGitWorkspace,
+      enabled: hasVcsWorkspace,
       run: (context) => { context.selectMainView("core:workspace.git"); },
     },
     {
@@ -137,10 +138,10 @@ export function createCoreActions(): PluginAction[] {
     },
     {
       id: "workspace.refresh-git",
-      title: "Refresh Git",
+      title: "Refresh Changes",
       shortcut: "mod+shift+g",
       group: "Workspace",
-      enabled: hasGitWorkspace,
+      enabled: hasVcsWorkspace,
       run: (context) => context.refreshGit(),
     },
     {
@@ -149,12 +150,12 @@ export function createCoreActions(): PluginAction[] {
       shortcut: "mod+shift+r",
       group: "Workspace",
       enabled: hasWorkspace,
-      run: (context) => context.state.workspaceTool === "core:workspace.git" && context.state.selectedWorkspace?.isGitRepo === true ? context.refreshGit() : context.refreshFiles(),
+      run: (context) => context.state.workspaceTool === "core:workspace.git" && hasVcsWorkspace(context) ? context.refreshGit() : context.refreshFiles(),
     },
     {
       id: "workspace.delete",
       title: "Delete Workspace",
-      description: "Remove the selected Git worktree",
+      description: "Remove a Git worktree or forget a Jujutsu workspace",
       group: "Workspace",
       enabled: hasDeletableWorkspace,
       run: (context) => context.deleteWorkspace(),
@@ -207,13 +208,14 @@ function hasWorkspace(context: { state: AppState }): boolean {
   return context.state.selectedWorkspace !== undefined;
 }
 
-function hasGitWorkspace(context: { state: AppState }): boolean {
-  return context.state.selectedWorkspace?.isGitRepo === true;
+function hasVcsWorkspace(context: { state: AppState }): boolean {
+  const workspace = context.state.selectedWorkspace;
+  return workspace?.isGitRepo === true || workspace?.vcs === "jj";
 }
 
 function hasDeletableWorkspace(context: { state: AppState }): boolean {
   const workspace = context.state.selectedWorkspace;
-  return workspace !== undefined && workspace.isGitWorktree && !workspace.isMain && !isWorkspaceDeletionPending(context.state, workspace);
+  return isDeletableWorkspace(workspace) && !isWorkspaceDeletionPending(context.state, workspace);
 }
 
 function hasArchivableSession(context: { state: AppState }): boolean {

--- a/src/client/src/plugins/core/panels.ts
+++ b/src/client/src/plugins/core/panels.ts
@@ -15,11 +15,12 @@ export function createCoreWorkspacePanels(): WorkspacePanelContribution[] {
     },
     {
       id: "workspace.git",
-      title: "Git",
+      title: "Changes",
+      titleFor: ({ workspace }) => workspace.vcs === "jj" ? "Jujutsu" : "Git",
       icon: renderBuiltinTabIcon("git"),
       order: 20,
-      visible: ({ workspace }) => workspace.isGitRepo,
-      render: renderGit,
+      visible: ({ workspace }) => workspace.isGitRepo || workspace.vcs === "jj",
+      render: renderChanges,
     },
     {
       id: "workspace.terminal",
@@ -41,7 +42,7 @@ function renderTerminal(context: WorkspacePanelContext): TemplateResult {
   return html`<terminal-panel .workspace=${context.workspace} .machineId=${context.machine.id} .selectedTerminalId=${context.selectedTerminalId} .autoStart=${context.terminalAutoStart} .onSelectTerminal=${context.onSelectTerminal}></terminal-panel>`;
 }
 
-function renderGit(context: WorkspacePanelContext): TemplateResult {
+function renderChanges(context: WorkspacePanelContext): TemplateResult {
   return html`<workspace-git-panel .context=${context}></workspace-git-panel>`;
 }
 

--- a/src/client/src/plugins/registry.test.ts
+++ b/src/client/src/plugins/registry.test.ts
@@ -6,7 +6,7 @@ import { markCachedNewSessionInfo } from "../cachedNewSessions";
 import { PI_WEB_CAPABILITIES } from "../../../shared/capabilities";
 import { machineScopedPluginId } from "../../../shared/machinePluginIds";
 import { corePlugin } from "./core";
-import { PluginRegistry } from "./registry";
+import { installWorkspacePanelScope, PluginRegistry } from "./registry";
 import { themePackPlugin } from "./themes";
 import type { PluginRuntimeContext, ThemeTokens, WorkspaceFiles, WorkspaceHost, WorkspaceLabelContext, WorkspaceLabelItem, WorkspacePanelContext } from "./types";
 
@@ -90,6 +90,26 @@ describe("PluginRegistry", () => {
 
     expect(panel?.icon).toBeDefined();
     expect(panel?.render(createWorkspacePanelContext("local"))).toBeDefined();
+  });
+
+  it("scopes context-aware workspace panel titles to the owning plugin", () => {
+    const registry = new PluginRegistry();
+    registry.register({
+      id: "example",
+      plugin: {
+        apiVersion: 1,
+        name: "Example",
+        activate: () => ({
+          contributions: {
+            workspacePanels: [{ id: "workspace.title", title: "Fallback", titleFor: (context) => context.workspace.label, render: () => html`<p>Panel</p>` }],
+          },
+        }),
+      },
+    });
+    const baseContext = createWorkspacePanelContext("local");
+    const context = installWorkspacePanelScope(baseContext, (pluginId) => ({ ...baseContext, workspace: { ...baseContext.workspace, label: pluginId } }));
+
+    expect(registry.getWorkspacePanels()[0]?.titleFor?.(context)).toBe("example");
   });
 
   it("exposes the prompt helper to workspace panel callbacks", () => {

--- a/src/client/src/plugins/registry.ts
+++ b/src/client/src/plugins/registry.ts
@@ -107,6 +107,7 @@ export class PluginRegistry {
   private qualifyWorkspacePanel(pluginId: string, panel: WorkspacePanelContribution, machineId: string | undefined, sourcePluginId: string | undefined): QualifiedWorkspacePanelContribution {
     const id = this.qualify(pluginId, panel.id);
     const badge = panel.badge;
+    const titleFor = panel.titleFor;
     const visible = panel.visible;
     return {
       ...panel,
@@ -115,6 +116,7 @@ export class PluginRegistry {
       localId: panel.id,
       ...(machineId === undefined ? {} : { machineId }),
       visible: (context: WorkspacePanelContext) => this.isContributionActive(pluginId, machineId, context.machine.id, sourcePluginId) && (visible?.(workspacePanelContextFor(context, pluginId)) ?? true),
+      ...(titleFor === undefined ? {} : { titleFor: (context: WorkspacePanelContext) => titleFor(workspacePanelContextFor(context, pluginId)) }),
       ...(badge === undefined ? {} : { badge: (context: WorkspacePanelContext) => this.isContributionActive(pluginId, machineId, context.machine.id, sourcePluginId) ? badge(workspacePanelContextFor(context, pluginId)) : undefined }),
       render: (context: WorkspacePanelContext) => panel.render(workspacePanelContextFor(context, pluginId)),
     };

--- a/src/client/src/plugins/types.ts
+++ b/src/client/src/plugins/types.ts
@@ -179,6 +179,7 @@ export type WorkspacePanelIcon = TemplateResult;
 export interface WorkspacePanelContribution {
   id: LocalContributionId;
   title: string;
+  titleFor?: (context: WorkspacePanelContext) => string;
   icon?: WorkspacePanelIcon;
   order?: number;
   visible?: (context: WorkspacePanelContext) => boolean;

--- a/src/plugin-api.ts
+++ b/src/plugin-api.ts
@@ -125,6 +125,10 @@ export interface Workspace {
   path: string;
   label: string;
   branch?: string;
+  /** VCS used to discover and manage this workspace. */
+  vcs?: "git" | "jj";
+  /** VCS-native workspace name, when it differs from a Git branch. */
+  vcsWorkspaceName?: string;
   isMain: boolean;
   isGitRepo: boolean;
   isGitWorktree: boolean;
@@ -182,6 +186,8 @@ export type WorkspacePanelIcon = TemplateResult;
 export interface WorkspacePanelContribution {
   id: LocalContributionId;
   title: string;
+  /** Optional context-aware title, for example to distinguish Git and Jujutsu workspaces. */
+  titleFor?: (context: WorkspacePanelContext) => string;
   icon?: WorkspacePanelIcon;
   order?: number;
   visible?: (context: WorkspacePanelContext) => boolean;

--- a/src/server/git/gitService.test.ts
+++ b/src/server/git/gitService.test.ts
@@ -2,8 +2,8 @@ import { execFileSync } from "node:child_process";
 import { mkdtempSync, rmSync, writeFileSync, renameSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { afterAll, describe, expect, it } from "vitest";
-import { gitDiff, gitStatus } from "./gitService.js";
+import { afterAll, describe, expect, it, vi } from "vitest";
+import { gitDiff, gitStatus, jjDiff, jjStatus } from "./gitService.js";
 
 // Isolate from any global/system git config and force a deterministic identity;
 // `protocol.file.allow` is required for `submodule add` from a local path.
@@ -243,5 +243,47 @@ describe("gitDiff routing into submodules", () => {
     const diff = await gitDiff(dir, { path: "HARL" });
     expect(diff.path).toBe("HARL");
     expect(diff.diff).toContain("Subproject commit");
+  });
+});
+
+const result = (stdout: string) => ({ code: 0, stdout, stderr: "", truncated: false });
+
+describe("Jujutsu workspace changes", () => {
+  it("maps the working-copy summary into the existing changes contract", async () => {
+    const run = vi.fn()
+      .mockResolvedValueOnce(result(["M", '"src/main.ts"', "0", "A", '"new file.txt"', "0", "D", '"old.ts"', "0", "M", '"conflicted.ts"', "1", ""].join("\0")))
+      .mockResolvedValueOnce(result("abcdefgh\0describe jj support"));
+
+    const status = await jjStatus("/repo", false, run);
+
+    expect(status).toMatchObject({
+      isGitRepo: false,
+      vcs: "jj",
+      branch: "abcdefgh · describe jj support",
+      files: [
+        { path: "src/main.ts", index: "unmodified", workingTree: "modified" },
+        { path: "new file.txt", index: "unmodified", workingTree: "added" },
+        { path: "old.ts", index: "unmodified", workingTree: "deleted" },
+        { path: "conflicted.ts", index: "unmodified", workingTree: "conflicted" },
+      ],
+    });
+    expect(status.hash).not.toBe("");
+    expect(run).toHaveBeenNthCalledWith(1, "/repo", ["diff", "--color=never", "-T", 'status_char ++ "\\0" ++ json(path) ++ "\\0" ++ if(target.conflict(), "1", "0") ++ "\\0"']);
+  });
+
+  it("rejects a truncated Jujutsu status before parsing a partial path record", async () => {
+    const run = vi.fn().mockResolvedValue({ code: 0, stdout: 'M\0"partial', stderr: "", truncated: true });
+
+    await expect(jjStatus("/repo", false, run)).rejects.toThrow("exceeds the 2 MiB output limit");
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns a Git-format working-copy diff and an empty staged diff", async () => {
+    const run = vi.fn().mockResolvedValue(result("diff --git a/file.ts b/file.ts\n"));
+
+    await expect(jjDiff("/repo", { path: "file (1).ts" }, run)).resolves.toMatchObject({ vcs: "jj", staged: false, diff: "diff --git a/file.ts b/file.ts\n" });
+    await expect(jjDiff("/repo", { path: "file (1).ts", staged: true }, run)).resolves.toMatchObject({ vcs: "jj", staged: true, diff: "" });
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(run).toHaveBeenCalledWith("/repo", ["diff", "--git", "--color=never", "--", 'root-file:"file (1).ts"']);
   });
 });

--- a/src/server/git/gitService.ts
+++ b/src/server/git/gitService.ts
@@ -3,6 +3,7 @@ import { spawn } from "node:child_process";
 import { existsSync } from "node:fs";
 import { join } from "node:path";
 import type { GitDiffResponse, GitFileState, GitStatusFile, GitStatusResponse } from "../../shared/apiTypes.js";
+import { parseJsonString } from "../vcsOutput.js";
 import { normalizeRelativePath } from "../workspaces/pathSafety.js";
 import { sanitizedGitEnv } from "./gitEnv.js";
 
@@ -35,6 +36,15 @@ interface ParsedStatus {
   submodules: SubmoduleRecord[];
 }
 
+interface CommandResult {
+  code: number;
+  stdout: string;
+  stderr: string;
+  truncated: boolean;
+}
+
+type JjRunner = (cwd: string, args: string[]) => Promise<CommandResult>;
+
 export async function gitStatus(cwd: string): Promise<GitStatusResponse> {
   const result = await runGit(cwd, ["status", "--porcelain=v2", "--branch", "--untracked-files=all", "-z"]);
   if (result.code !== 0) return { isGitRepo: false, hash: hash(result.stdout + result.stderr), files: [], submodules: [] };
@@ -66,6 +76,7 @@ async function expandSubmodules(cwd: string, parsed: ParsedStatus, topRaw: strin
 
   return {
     isGitRepo: true,
+    vcs: "git",
     hash: hash(topRaw + extraForHash),
     ...(parsed.branch === undefined ? {} : { branch: parsed.branch }),
     ...(parsed.upstream === undefined ? {} : { upstream: parsed.upstream }),
@@ -116,6 +127,17 @@ async function resolveSubmoduleToCommit(cwd: string, sub: SubmoduleRecord): Prom
   return head.code === 0 && resolved !== "" ? resolved : sub.indexOid;
 }
 
+export async function jjStatus(cwd: string, isGitRepo: boolean, run: JjRunner = runJj): Promise<GitStatusResponse> {
+  const summary = await run(cwd, ["diff", "--color=never", "-T", 'status_char ++ "\\0" ++ json(path) ++ "\\0" ++ if(target.conflict(), "1", "0") ++ "\\0"']);
+  if (summary.code !== 0) throw new Error(summary.stderr.trim() || "jj diff failed");
+  if (summary.truncated) throw new Error("Jujutsu status exceeds the 2 MiB output limit");
+  const commit = await run(cwd, ["--ignore-working-copy", "--color=never", "log", "--no-graph", "-r", "@", "-T", 'change_id.short(8) ++ "\\0" ++ description.first_line()']);
+  if (commit.code !== 0) throw new Error(commit.stderr.trim() || "jj log failed");
+  const [changeId = "@", description = ""] = commit.stdout.split("\0");
+  const branch = description === "" ? changeId : `${changeId} · ${description}`;
+  return { isGitRepo, vcs: "jj", hash: hash(summary.stdout + commit.stdout), branch, files: parseJjSummary(summary.stdout), submodules: [] };
+}
+
 export async function gitDiff(cwd: string, options: { path?: string; staged?: boolean }): Promise<GitDiffResponse> {
   const staged = options.staged === true;
   let path: string | undefined;
@@ -135,9 +157,20 @@ export async function gitDiff(cwd: string, options: { path?: string; staged?: bo
   if (!staged && path !== undefined && result.stdout === "" && await isUntracked(cwd, path)) {
     const untracked = await runGit(cwd, ["diff", "--no-ext-diff", "--color=never", "--no-index", "/dev/null", "--", path]);
     if (untracked.code !== 0 && untracked.code !== 1) throw new Error(untracked.stderr.trim() || "git diff failed");
-    return { path, staged, hash: hash(untracked.stdout), diff: untracked.stdout, truncated: untracked.truncated };
+    return { path, vcs: "git", staged, hash: hash(untracked.stdout), diff: untracked.stdout, truncated: untracked.truncated };
   }
-  return { ...(path === undefined ? {} : { path }), staged, hash: hash(result.stdout), diff: result.stdout, truncated: result.truncated };
+  return { ...(path === undefined ? {} : { path }), vcs: "git", staged, hash: hash(result.stdout), diff: result.stdout, truncated: result.truncated };
+}
+
+export async function jjDiff(cwd: string, options: { path?: string; staged?: boolean }, run: JjRunner = runJj): Promise<GitDiffResponse> {
+  const staged = options.staged === true;
+  let path: string | undefined;
+  if (options.path !== undefined && options.path !== "") path = normalizeRelativePath(options.path);
+  if (staged) return { ...(path === undefined ? {} : { path }), vcs: "jj", staged, hash: hash(""), diff: "", truncated: false };
+
+  const result = await run(cwd, ["diff", "--git", "--color=never", ...(path === undefined ? [] : ["--", `root-file:${JSON.stringify(path)}`])]);
+  if (result.code !== 0) throw new Error(result.stderr.trim() || "jj diff failed");
+  return { ...(path === undefined ? {} : { path }), vcs: "jj", staged, hash: hash(result.stdout), diff: result.stdout, truncated: result.truncated };
 }
 
 /**
@@ -262,6 +295,32 @@ function parseStatus(raw: string, options: { deferSubmodules: boolean }): Parsed
   return { isGitRepo: true, ...(branch === undefined ? {} : { branch }), ...(upstream === undefined ? {} : { upstream }), ...(ahead === undefined ? {} : { ahead }), ...(behind === undefined ? {} : { behind }), files, submodules };
 }
 
+function parseJjSummary(raw: string): GitStatusFile[] {
+  const fields = raw.split("\0").filter((field) => field !== "");
+  const files: GitStatusFile[] = [];
+  for (let index = 0; index < fields.length; index += 3) {
+    const code = fields[index];
+    const encodedPath = fields[index + 1];
+    const conflicted = fields[index + 2];
+    if (encodedPath === undefined) continue;
+    const path = parseJsonString(encodedPath, "Invalid Jujutsu diff path");
+    files.push({ path, index: "unmodified", workingTree: conflicted === "1" ? "conflicted" : jjStateFor(code) });
+  }
+  return files;
+}
+
+function jjStateFor(code: string | undefined): GitFileState {
+  switch (code) {
+    case undefined: return "unmodified";
+    case "M": return "modified";
+    case "A": return "added";
+    case "D": return "deleted";
+    case "C": return "copied";
+    case "R": return "renamed";
+    default: return "unmodified";
+  }
+}
+
 function stateFor(code: string | undefined): GitFileState {
   if (code === undefined) return "unmodified";
   switch (code) {
@@ -293,9 +352,17 @@ function hash(value: string): string {
   return createHash("sha1").update(value).digest("hex");
 }
 
-async function runGit(cwd: string, args: string[]): Promise<{ code: number; stdout: string; stderr: string; truncated: boolean }> {
+async function runGit(cwd: string, args: string[]): Promise<CommandResult> {
+  return runCommand("git", cwd, args, sanitizedGitEnv());
+}
+
+async function runJj(cwd: string, args: string[]): Promise<CommandResult> {
+  return runCommand("jj", cwd, args, process.env);
+}
+
+async function runCommand(command: string, cwd: string, args: string[], env: NodeJS.ProcessEnv): Promise<CommandResult> {
   return new Promise((resolve, reject) => {
-    const child = spawn("git", args, { cwd, env: sanitizedGitEnv(), stdio: ["ignore", "pipe", "pipe"] });
+    const child = spawn(command, args, { cwd, env, stdio: ["ignore", "pipe", "pipe"] });
     const timer = setTimeout(() => { child.kill("SIGKILL"); }, 10000);
     let stdout = Buffer.alloc(0);
     let stderr = Buffer.alloc(0);

--- a/src/server/gitRoutes.ts
+++ b/src/server/gitRoutes.ts
@@ -2,13 +2,13 @@ import type { FastifyInstance } from "fastify";
 import type { ProjectService } from "./projects/projectService.js";
 import type { WorkspaceService } from "./workspaces/workspaceService.js";
 import { resolveWorkspaceContext } from "./workspaces/workspaceContext.js";
-import { gitDiff, gitStatus } from "./git/gitService.js";
+import { gitDiff, gitStatus, jjDiff, jjStatus } from "./git/gitService.js";
 
 export function registerGitRoutes(app: FastifyInstance, projects: ProjectService, workspaces: WorkspaceService, prefix = "/api"): void {
   app.get<{ Params: { projectId: string; workspaceId: string } }>(`${prefix}/projects/:projectId/workspaces/:workspaceId/git/status`, async (request, reply) => {
     try {
       const context = await resolveWorkspaceContext(projects, workspaces, request.params.projectId, request.params.workspaceId);
-      return await gitStatus(context.root);
+      return context.workspace.vcs === "jj" ? await jjStatus(context.root, context.workspace.isGitRepo) : await gitStatus(context.root);
     } catch (error) {
       return reply.code(400).send({ error: error instanceof Error ? error.message : String(error) });
     }
@@ -17,7 +17,8 @@ export function registerGitRoutes(app: FastifyInstance, projects: ProjectService
   app.get<{ Params: { projectId: string; workspaceId: string }; Querystring: { path?: string; staged?: string } }>(`${prefix}/projects/:projectId/workspaces/:workspaceId/git/diff`, async (request, reply) => {
     try {
       const context = await resolveWorkspaceContext(projects, workspaces, request.params.projectId, request.params.workspaceId);
-      return await gitDiff(context.root, { ...(request.query.path === undefined ? {} : { path: request.query.path }), staged: request.query.staged === "true" });
+      const options = { ...(request.query.path === undefined ? {} : { path: request.query.path }), staged: request.query.staged === "true" };
+      return context.workspace.vcs === "jj" ? await jjDiff(context.root, options) : await gitDiff(context.root, options);
     } catch (error) {
       return reply.code(400).send({ error: error instanceof Error ? error.message : String(error) });
     }

--- a/src/server/vcsOutput.ts
+++ b/src/server/vcsOutput.ts
@@ -1,0 +1,10 @@
+export function parseJsonString(value: string, errorMessage: string): string {
+  try {
+    const parsed: unknown = JSON.parse(value);
+    if (typeof parsed !== "string") throw new Error(errorMessage);
+    return parsed;
+  } catch (error) {
+    if (error instanceof Error && error.message === errorMessage) throw error;
+    throw new Error(errorMessage, { cause: error });
+  }
+}

--- a/src/server/workspaces/gitWorktreeDiscovery.ts
+++ b/src/server/workspaces/gitWorktreeDiscovery.ts
@@ -22,6 +22,11 @@ export async function isGitRepository(path: string): Promise<boolean> {
   }
 }
 
+export async function discoverGitWorkspaceRoot(path: string): Promise<string> {
+  const { stdout } = await execFileAsync("git", ["-C", path, "rev-parse", "--show-toplevel"], { env: sanitizedGitEnv() });
+  return stdout.trim();
+}
+
 export async function discoverGitWorktrees(path: string): Promise<GitWorktreeInfo[]> {
   const { stdout } = await execFileAsync("git", ["-C", path, "worktree", "list", "--porcelain"], { env: sanitizedGitEnv() });
   return parseGitWorktreeList(stdout);

--- a/src/server/workspaces/jjWorkspaceDiscovery.test.ts
+++ b/src/server/workspaces/jjWorkspaceDiscovery.test.ts
@@ -1,0 +1,30 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { isJjRepository, parseJjWorkspaceList } from "./jjWorkspaceDiscovery.js";
+
+describe("Jujutsu workspace discovery", () => {
+  it("does not require the jj executable for directories without Jujutsu metadata", async () => {
+    const directory = await mkdtemp(join(tmpdir(), "pi-web-plain-"));
+    try {
+      await expect(isJjRepository(directory)).resolves.toBe(false);
+    } finally {
+      await rm(directory, { recursive: true, force: true });
+    }
+  });
+
+  it("uses the current root when legacy workspace metadata has no recorded path", () => {
+    const raw = [
+      '"feature"', "/repo-feature", "0",
+      '"default"', "<Error: Workspace has no recorded path: default>", "1",
+      '"stale"', "<Error: Workspace has no recorded path: stale>", "0",
+      "",
+    ].join("\0");
+
+    expect(parseJjWorkspaceList(raw, "/repo")).toEqual([
+      { name: "feature", path: "/repo-feature", isCurrent: false },
+      { name: "default", path: "/repo", isCurrent: true },
+    ]);
+  });
+});

--- a/src/server/workspaces/jjWorkspaceDiscovery.ts
+++ b/src/server/workspaces/jjWorkspaceDiscovery.ts
@@ -1,0 +1,89 @@
+import { execFile } from "node:child_process";
+import { stat } from "node:fs/promises";
+import { dirname, join, parse } from "node:path";
+import { promisify } from "node:util";
+import { parseJsonString } from "../vcsOutput.js";
+
+const execFileAsync = promisify(execFile);
+
+export interface JjWorkspaceInfo {
+  name: string;
+  path: string;
+  isCurrent: boolean;
+}
+
+export async function isJjRepository(path: string): Promise<boolean> {
+  const repositoryPath = await findJjMarkerRoot(path);
+  if (repositoryPath === undefined) return false;
+  try {
+    await execFileAsync("jj", ["--ignore-working-copy", "--color=never", "-R", repositoryPath, "workspace", "root"]);
+    return true;
+  } catch (error) {
+    if (isNodeErrorWithCode(error, "ENOENT")) throw new Error("Jujutsu repository detected, but the jj executable is not available on PI WEB's PATH", { cause: error });
+    throw new Error(`Failed to inspect Jujutsu repository: ${commandErrorMessage(error)}`, { cause: error });
+  }
+}
+
+export async function discoverJjWorkspaces(path: string): Promise<JjWorkspaceInfo[]> {
+  const repositoryPath = await findJjMarkerRoot(path);
+  if (repositoryPath === undefined) throw new Error("Jujutsu repository metadata not found");
+  const args = ["--ignore-working-copy", "--color=never", "-R", repositoryPath];
+  const [{ stdout }, { stdout: currentRoot }] = await Promise.all([
+    execFileAsync("jj", [...args, "workspace", "list", "-T", 'json(name) ++ "\\0" ++ root ++ "\\0" ++ if(target.current_working_copy(), "1", "0") ++ "\\0"']),
+    execFileAsync("jj", [...args, "workspace", "root"]),
+  ]);
+  return parseJjWorkspaceList(stdout, currentRoot.trim());
+}
+
+export function parseJjWorkspaceList(raw: string, currentRoot: string): JjWorkspaceInfo[] {
+  const fields = raw.split("\0").filter((field) => field !== "");
+  const workspaces: JjWorkspaceInfo[] = [];
+  for (let index = 0; index < fields.length; index += 3) {
+    const encodedName = fields[index];
+    const recordedPath = fields[index + 1];
+    const isCurrent = fields[index + 2] === "1";
+    if (encodedName === undefined || recordedPath === undefined) continue;
+    const workspacePath = isCurrent ? currentRoot : recordedPath;
+    if (workspacePath.startsWith("<Error:")) continue;
+    workspaces.push({ name: parseJsonString(encodedName, "Invalid Jujutsu workspace name"), path: workspacePath, isCurrent });
+  }
+  return workspaces;
+}
+
+export async function resolveJjWorkspaceRoot(repositoryPath: string, workspaceName: string): Promise<string> {
+  try {
+    const { stdout } = await execFileAsync("jj", ["--ignore-working-copy", "--color=never", "-R", repositoryPath, "workspace", "root", "--name", workspaceName]);
+    return stdout.trim();
+  } catch (error) {
+    throw new Error(`Failed to resolve Jujutsu workspace ${workspaceName}: ${commandErrorMessage(error)}`, { cause: error });
+  }
+}
+
+async function findJjMarkerRoot(path: string): Promise<string | undefined> {
+  let current = path;
+  const root = parse(path).root;
+  while (current !== root) {
+    if (await pathExists(join(current, ".jj"))) return current;
+    current = dirname(current);
+  }
+  return await pathExists(join(root, ".jj")) ? root : undefined;
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch (error) {
+    if (isNodeErrorWithCode(error, "ENOENT") || isNodeErrorWithCode(error, "ENOTDIR")) return false;
+    throw error;
+  }
+}
+
+function commandErrorMessage(error: unknown): string {
+  if (typeof error === "object" && error !== null && "stderr" in error && typeof error.stderr === "string" && error.stderr.trim() !== "") return error.stderr.trim();
+  return error instanceof Error ? error.message : String(error);
+}
+
+function isNodeErrorWithCode(error: unknown, code: string): error is NodeJS.ErrnoException {
+  return typeof error === "object" && error !== null && "code" in error && error.code === code;
+}

--- a/src/server/workspaces/workspaceDeletionRoutes.test.ts
+++ b/src/server/workspaces/workspaceDeletionRoutes.test.ts
@@ -36,16 +36,29 @@ const targetWorkspace: Workspace = {
   path: "/repo/feature path",
   label: "feature",
   branch: "feature/branch",
+  vcs: "git",
   isMain: false,
   isGitRepo: true,
   isGitWorktree: true,
+};
+
+const jjWorkspace: Workspace = {
+  id: "jj-feature",
+  projectId: project.id,
+  path: "/repo/jj feature",
+  label: "agent feature",
+  vcs: "jj",
+  vcsWorkspaceName: "agent feature",
+  isMain: false,
+  isGitRepo: false,
+  isGitWorktree: false,
 };
 
 beforeEach(() => {
   app = Fastify({ logger: false });
   daemonRequests = [];
   closeStatusCode = 200;
-  registerWorkspaceDeletionRoutes(app, fakeProjects(), fakeWorkspaces([mainWorkspace, targetWorkspace]), fakeDaemon(), "/api");
+  registerWorkspaceDeletionRoutes(app, fakeProjects(), fakeWorkspaces([mainWorkspace, targetWorkspace, jjWorkspace]), fakeDaemon(), "/api", { validateDeletion: () => Promise.resolve() });
 });
 
 afterEach(async () => {
@@ -80,6 +93,19 @@ describe("workspace deletion routes", () => {
     ]);
   });
 
+  it("forgets and removes a secondary Jujutsu workspace", async () => {
+    const response = await app.inject({ method: "DELETE", url: "/api/projects/p1/workspaces/jj-feature" });
+
+    expect(response.statusCode).toBe(200);
+    expect(daemonRequests[0]).toEqual({ method: "DELETE", path: `/terminals?cwd=${encodeURIComponent(jjWorkspace.path)}` });
+    expect(daemonRequests[1]).toMatchObject({ method: "POST", path: "/terminal-command-runs" });
+    expect(daemonRequests[1]?.body).toMatchObject({
+      cwd: "/repo",
+      title: "Delete workspace: agent feature",
+      command: "jj -R '/repo' workspace forget 'agent feature'",
+    });
+  });
+
   it("does not start deletion when terminal cleanup fails", async () => {
     closeStatusCode = 500;
 
@@ -94,7 +120,7 @@ describe("workspace deletion routes", () => {
     const response = await app.inject({ method: "DELETE", url: "/api/projects/p1/workspaces/main" });
 
     expect(response.statusCode).toBe(400);
-    expect(response.json()).toEqual({ error: "Only secondary Git worktrees can be deleted" });
+    expect(response.json()).toEqual({ error: "Only secondary Git worktrees or Jujutsu workspaces can be deleted" });
     expect(daemonRequests).toEqual([]);
   });
 });

--- a/src/server/workspaces/workspaceDeletionRoutes.ts
+++ b/src/server/workspaces/workspaceDeletionRoutes.ts
@@ -1,30 +1,38 @@
 import type { FastifyInstance } from "fastify";
 import type { TerminalCommandRun, Workspace } from "../../shared/apiTypes.js";
 import { workspaceDeletionMetadata } from "../../shared/workspaceDeletion.js";
+import { isDeletableWorkspace } from "../../shared/workspaces.js";
 import { SessionDaemonClient } from "../../sessiond/sessionDaemonClient.js";
 import type { ProjectService } from "../projects/projectService.js";
 import type { SessionProxyDaemon } from "../sessiond/sessionProxyRoutes.js";
+import { validateWorkspaceDeletion, type WorkspaceDeletionValidationInput } from "./workspaceDeletionSafety.js";
 import type { WorkspaceService } from "./workspaceService.js";
 
-export function registerWorkspaceDeletionRoutes(app: FastifyInstance, projects: ProjectService, workspaces: WorkspaceService, daemon: SessionProxyDaemon = new SessionDaemonClient(), prefix = "/api"): void {
+export interface WorkspaceDeletionRouteOptions {
+  validateDeletion?: (input: WorkspaceDeletionValidationInput) => Promise<void>;
+}
+
+export function registerWorkspaceDeletionRoutes(app: FastifyInstance, projects: ProjectService, workspaces: WorkspaceService, daemon: SessionProxyDaemon = new SessionDaemonClient(), prefix = "/api", options: WorkspaceDeletionRouteOptions = {}): void {
+  const validateDeletion = options.validateDeletion ?? validateWorkspaceDeletion;
   app.delete<{ Params: { projectId: string; workspaceId: string } }>(`${prefix}/projects/:projectId/workspaces/:workspaceId`, async (request, reply) => {
     try {
-      return await deleteWorkspace(projects, workspaces, daemon, request.params.projectId, request.params.workspaceId);
+      return await deleteWorkspace(projects, workspaces, daemon, validateDeletion, request.params.projectId, request.params.workspaceId);
     } catch (error) {
       return reply.code(400).send({ error: error instanceof Error ? error.message : String(error) });
     }
   });
 }
 
-async function deleteWorkspace(projects: ProjectService, workspaces: WorkspaceService, daemon: SessionProxyDaemon, projectId: string, workspaceId: string): Promise<TerminalCommandRun> {
+async function deleteWorkspace(projects: ProjectService, workspaces: WorkspaceService, daemon: SessionProxyDaemon, validateDeletion: (input: WorkspaceDeletionValidationInput) => Promise<void>, projectId: string, workspaceId: string): Promise<TerminalCommandRun> {
   const project = await projects.requireProject(projectId);
   const projectWorkspaces = await workspaces.list(project);
   const targetWorkspace = projectWorkspaces.find((workspace) => workspace.id === workspaceId);
   if (targetWorkspace === undefined) throw new Error("Workspace not found");
-  if (!canDeleteWorkspace(targetWorkspace)) throw new Error("Only secondary Git worktrees can be deleted");
+  if (!isDeletableWorkspace(targetWorkspace)) throw new Error("Only secondary Git worktrees or Jujutsu workspaces can be deleted");
 
   const commandWorkspace = projectWorkspaces.find((workspace) => workspace.isMain) ?? projectWorkspaces.find((workspace) => workspace.id !== targetWorkspace.id);
   if (commandWorkspace === undefined) throw new Error("Project main workspace not found");
+  await validateDeletion({ projectPath: project.path, targetWorkspace, commandWorkspace });
 
   const closeResponse = await requestJson(daemon, "DELETE", `/terminals?cwd=${encodeURIComponent(targetWorkspace.path)}`);
   if (closeResponse.statusCode < 200 || closeResponse.statusCode >= 300) throw new Error(`Failed to close workspace terminals: ${responseError(closeResponse.body, closeResponse.statusCode)}`);
@@ -35,15 +43,18 @@ async function deleteWorkspace(projects: ProjectService, workspaces: WorkspaceSe
     workspaceId: commandWorkspace.id,
     cwd: commandWorkspace.path,
     title: `Delete workspace: ${workspaceLabel(targetWorkspace)}`,
-    command: `git worktree remove ${shellQuote(targetWorkspace.path)}`,
+    command: workspaceDeletionCommand(targetWorkspace, commandWorkspace),
     metadata: workspaceDeletionMetadata(targetWorkspace),
   });
   if (deleteResponse.statusCode < 200 || deleteResponse.statusCode >= 300) throw new Error(`Failed to start workspace deletion: ${responseError(deleteResponse.body, deleteResponse.statusCode)}`);
   return parseTerminalCommandRun(deleteResponse.body);
 }
 
-function canDeleteWorkspace(workspace: Workspace): boolean {
-  return workspace.isGitWorktree && !workspace.isMain;
+function workspaceDeletionCommand(workspace: Workspace, commandWorkspace: Workspace): string {
+  if (workspace.vcs === "jj" && workspace.vcsWorkspaceName !== undefined) {
+    return `jj -R ${shellQuote(commandWorkspace.path)} workspace forget ${shellQuote(workspace.vcsWorkspaceName)}`;
+  }
+  return `git worktree remove ${shellQuote(workspace.path)}`;
 }
 
 function workspaceLabel(workspace: Workspace): string {
@@ -52,7 +63,16 @@ function workspaceLabel(workspace: Workspace): string {
 
 async function requestJson(daemon: SessionProxyDaemon, method: string, path: string, body?: unknown): Promise<{ statusCode: number; body: unknown }> {
   const response = await daemon.request(method, path, body);
-  return { statusCode: response.statusCode, body: response.body === "" ? undefined : JSON.parse(response.body) };
+  return { statusCode: response.statusCode, body: response.body === "" ? undefined : parseJsonBody(response.body) };
+}
+
+function parseJsonBody(body: string): unknown {
+  try {
+    const parsed: unknown = JSON.parse(body);
+    return parsed;
+  } catch (error) {
+    throw new Error("Invalid JSON response from session daemon", { cause: error });
+  }
 }
 
 function responseError(body: unknown, statusCode: number): string {

--- a/src/server/workspaces/workspaceDeletionSafety.test.ts
+++ b/src/server/workspaces/workspaceDeletionSafety.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Workspace } from "../../shared/apiTypes.js";
+import { validateWorkspaceDeletion, type WorkspaceDeletionValidationDependencies } from "./workspaceDeletionSafety.js";
+
+const mainWorkspace = workspace({ id: "main", path: "/repo", isMain: true, vcsWorkspaceName: "default" });
+const targetWorkspace = workspace({ id: "feature", path: "/tmp/feature", vcsWorkspaceName: "feature" });
+
+function workspace(patch: Partial<Workspace>): Workspace {
+  return {
+    id: "workspace",
+    projectId: "project",
+    path: "/workspace",
+    label: "workspace",
+    vcs: "jj",
+    vcsWorkspaceName: "workspace",
+    isMain: false,
+    isGitRepo: false,
+    isGitWorktree: false,
+    ...patch,
+  };
+}
+
+function dependencies(paths: Record<string, string> = {}): WorkspaceDeletionValidationDependencies {
+  return {
+    realpath: vi.fn((path: string) => Promise.resolve(paths[path] ?? path)),
+    resolveJjWorkspaceRoot: vi.fn(() => Promise.resolve("/tmp/feature")),
+  };
+}
+
+describe("workspace deletion safety", () => {
+  it("rejects deleting the workspace root containing a registered project subdirectory", async () => {
+    await expect(validateWorkspaceDeletion({
+      projectPath: "/repo/subdir",
+      targetWorkspace: workspace({ path: "/repo", isMain: false }),
+      commandWorkspace: workspace({ path: "/tmp/other" }),
+    }, dependencies())).rejects.toThrow("containing the registered project");
+  });
+
+  it("rejects stale Jujutsu workspace path metadata", async () => {
+    const deps = dependencies();
+    deps.resolveJjWorkspaceRoot = vi.fn(() => Promise.resolve("/tmp/moved"));
+
+    await expect(validateWorkspaceDeletion({ projectPath: "/repo", targetWorkspace, commandWorkspace: mainWorkspace }, deps)).rejects.toThrow("workspace path changed");
+  });
+
+  it("accepts a distinct Jujutsu workspace whose live root matches", async () => {
+    await expect(validateWorkspaceDeletion({ projectPath: "/repo", targetWorkspace, commandWorkspace: mainWorkspace }, dependencies())).resolves.toBeUndefined();
+  });
+});

--- a/src/server/workspaces/workspaceDeletionSafety.ts
+++ b/src/server/workspaces/workspaceDeletionSafety.ts
@@ -1,0 +1,46 @@
+import { realpath } from "node:fs/promises";
+import { isAbsolute, parse, relative } from "node:path";
+import type { Workspace } from "../../shared/apiTypes.js";
+import { resolveJjWorkspaceRoot } from "./jjWorkspaceDiscovery.js";
+
+export interface WorkspaceDeletionValidationInput {
+  projectPath: string;
+  targetWorkspace: Workspace;
+  commandWorkspace: Workspace;
+}
+
+export interface WorkspaceDeletionValidationDependencies {
+  realpath(path: string): Promise<string>;
+  resolveJjWorkspaceRoot(repositoryPath: string, workspaceName: string): Promise<string>;
+}
+
+const defaultDependencies: WorkspaceDeletionValidationDependencies = {
+  realpath,
+  resolveJjWorkspaceRoot,
+};
+
+export async function validateWorkspaceDeletion(input: WorkspaceDeletionValidationInput, dependencies: WorkspaceDeletionValidationDependencies = defaultDependencies): Promise<void> {
+  const [projectPath, targetPath, commandPath] = await Promise.all([
+    dependencies.realpath(input.projectPath),
+    dependencies.realpath(input.targetWorkspace.path),
+    dependencies.realpath(input.commandWorkspace.path),
+  ]);
+
+  if (input.targetWorkspace.isMain) throw new Error("The current project workspace cannot be deleted");
+  if (targetPath === parse(targetPath).root) throw new Error("Refusing to delete a filesystem root");
+  if (targetPath === commandPath) throw new Error("The command workspace cannot delete itself");
+  if (isEqualOrAncestor(targetPath, projectPath)) throw new Error("The workspace containing the registered project cannot be deleted");
+
+  if (input.targetWorkspace.vcs === "jj") {
+    const workspaceName = input.targetWorkspace.vcsWorkspaceName;
+    if (workspaceName === undefined) throw new Error("Jujutsu workspace name is missing");
+    const recordedRoot = await dependencies.resolveJjWorkspaceRoot(commandPath, workspaceName);
+    const resolvedRoot = await dependencies.realpath(recordedRoot);
+    if (resolvedRoot !== targetPath) throw new Error("Jujutsu workspace path changed; refresh workspaces and try again");
+  }
+}
+
+function isEqualOrAncestor(ancestor: string, path: string): boolean {
+  const rel = relative(ancestor, path);
+  return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
+}

--- a/src/server/workspaces/workspaceService.test.ts
+++ b/src/server/workspaces/workspaceService.test.ts
@@ -1,70 +1,108 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { Project } from "../types.js";
-import type { GitWorktreeInfo } from "./gitWorktreeDiscovery.js";
-import { WorkspaceService, type WorkspaceGitPort } from "./workspaceService.js";
+import { WorkspaceService, type WorkspaceDiscovery } from "./workspaceService.js";
 
 const project: Project = {
   id: "p1",
   name: "Project",
   path: "/repo",
-  createdAt: "2026-05-25T00:00:00.000Z",
+  createdAt: "2026-07-01T00:00:00.000Z",
 };
 
-function serviceFor(worktrees: GitWorktreeInfo[], isGitRepo = true): WorkspaceService {
-  const git: WorkspaceGitPort = {
-    isGitRepository: () => Promise.resolve(isGitRepo),
-    discoverGitWorktrees: () => Promise.resolve(worktrees),
+function discovery(overrides: Partial<WorkspaceDiscovery> = {}): WorkspaceDiscovery {
+  return {
+    isGitRepository: vi.fn().mockResolvedValue(false),
+    discoverGitWorkspaceRoot: vi.fn().mockResolvedValue("/repo"),
+    discoverGitWorktrees: vi.fn().mockResolvedValue([]),
+    isJjRepository: vi.fn().mockResolvedValue(false),
+    discoverJjWorkspaces: vi.fn().mockResolvedValue([]),
+    ...overrides,
   };
-  return new WorkspaceService(git);
 }
 
-describe("WorkspaceService.list", () => {
-  it("hides a linked worktree whose checkout directory was removed outside PI WEB", async () => {
-    const service = serviceFor([
-      { path: "/repo", branch: "main" },
-      { path: "/repo-worktrees/gone", branch: "gone", prunable: true },
-      { path: "/repo-worktrees/live", branch: "live" },
-    ]);
+describe("WorkspaceService", () => {
+  it("discovers Jujutsu workspaces before falling back to Git worktrees", async () => {
+    const discoverGitWorktrees = vi.fn().mockResolvedValue([]);
+    const adapters = discovery({
+      isJjRepository: vi.fn().mockResolvedValue(true),
+      isGitRepository: vi.fn().mockResolvedValue(true),
+      discoverGitWorktrees,
+      discoverJjWorkspaces: vi.fn().mockResolvedValue([
+        { name: "default", path: "/repo", isCurrent: true },
+        { name: "feature", path: "/tmp/feature", isCurrent: false },
+      ]),
+    });
 
-    const workspaces = await service.list(project);
+    const workspaces = await new WorkspaceService(adapters).list(project);
+
+    expect(workspaces).toEqual([
+      expect.objectContaining({ path: "/repo", label: "default", vcs: "jj", vcsWorkspaceName: "default", isMain: true, isGitRepo: true, isGitWorktree: false }),
+      expect.objectContaining({ path: "/tmp/feature", label: "feature", vcs: "jj", vcsWorkspaceName: "feature", isMain: false, isGitRepo: true, isGitWorktree: false }),
+    ]);
+    expect(discoverGitWorktrees).not.toHaveBeenCalled();
+  });
+
+  it("marks the current Jujutsu workspace main when the registered project is a subdirectory", async () => {
+    const workspaces = await new WorkspaceService(discovery({
+      isJjRepository: vi.fn().mockResolvedValue(true),
+      discoverJjWorkspaces: vi.fn().mockResolvedValue([{ name: "default", path: "/repo", isCurrent: true }]),
+    })).list({ ...project, path: "/repo/subdir" });
+
+    expect(workspaces[0]).toMatchObject({ path: "/repo", isMain: true, vcs: "jj" });
+  });
+
+  it("marks the current Git worktree main when the registered project is a subdirectory", async () => {
+    const workspaces = await new WorkspaceService(discovery({
+      isGitRepository: vi.fn().mockResolvedValue(true),
+      discoverGitWorkspaceRoot: vi.fn().mockResolvedValue("/repo"),
+      discoverGitWorktrees: vi.fn().mockResolvedValue([{ path: "/repo", branch: "main" }, { path: "/tmp/feature", branch: "feature" }]),
+    })).list({ ...project, path: "/repo/subdir" });
+
+    expect(workspaces).toEqual([
+      expect.objectContaining({ path: "/repo", isMain: true, vcs: "git" }),
+      expect.objectContaining({ path: "/tmp/feature", isMain: false, vcs: "git" }),
+    ]);
+  });
+
+  it("hides prunable linked Git worktrees", async () => {
+    const workspaces = await new WorkspaceService(discovery({
+      isGitRepository: vi.fn().mockResolvedValue(true),
+      discoverGitWorktrees: vi.fn().mockResolvedValue([
+        { path: "/repo", branch: "main" },
+        { path: "/repo-worktrees/gone", branch: "gone", prunable: true },
+        { path: "/repo-worktrees/live", branch: "live" },
+      ]),
+    })).list(project);
 
     expect(workspaces.map((workspace) => workspace.path)).toEqual(["/repo", "/repo-worktrees/live"]);
   });
 
-  it("keeps a worktree that is present but not prunable, such as a locked one", async () => {
-    const service = serviceFor([
-      { path: "/repo", branch: "main" },
-      { path: "/repo-worktrees/kept", branch: "kept" },
-    ]);
-
-    const workspaces = await service.list(project);
-
-    expect(workspaces.map((workspace) => workspace.path)).toEqual(["/repo", "/repo-worktrees/kept"]);
-  });
-
-  it("keeps the project's own worktree even if git marks it prunable, so a project is never empty", async () => {
-    const service = serviceFor([{ path: "/repo", branch: "main", prunable: true }]);
-
-    const workspaces = await service.list(project);
+  it("keeps the project's own worktree if Git marks it prunable", async () => {
+    const workspaces = await new WorkspaceService(discovery({
+      isGitRepository: vi.fn().mockResolvedValue(true),
+      discoverGitWorktrees: vi.fn().mockResolvedValue([{ path: "/repo", branch: "main", prunable: true }]),
+    })).list(project);
 
     expect(workspaces).toEqual([expect.objectContaining({ path: "/repo", label: "main", isMain: true, isGitWorktree: true })]);
   });
 
-  it("falls back to the project itself when every linked worktree is filtered away", async () => {
-    const service = serviceFor([{ path: "/repo-worktrees/gone", branch: "gone", prunable: true }]);
+  it("falls back to the project when every linked worktree is prunable", async () => {
+    const workspaces = await new WorkspaceService(discovery({
+      isGitRepository: vi.fn().mockResolvedValue(true),
+      discoverGitWorktrees: vi.fn().mockResolvedValue([{ path: "/repo-worktrees/gone", branch: "gone", prunable: true }]),
+    })).list(project);
 
-    const workspaces = await service.list(project);
-
-    expect(workspaces).toEqual([expect.objectContaining({ path: "/repo", label: "Project", isMain: true, isGitRepo: true, isGitWorktree: false })]);
+    expect(workspaces).toEqual([expect.objectContaining({ path: "/repo", label: "Project", vcs: "git", isMain: true, isGitRepo: true, isGitWorktree: false })]);
   });
 
-  it("labels detached and unnamed worktrees without inventing a branch", async () => {
-    const service = serviceFor([
-      { path: "/repo", branch: "main" },
-      { path: "/repo-worktrees/detached", detached: true },
-    ]);
-
-    const workspaces = await service.list(project);
+  it("labels detached worktrees without inventing a branch", async () => {
+    const workspaces = await new WorkspaceService(discovery({
+      isGitRepository: vi.fn().mockResolvedValue(true),
+      discoverGitWorktrees: vi.fn().mockResolvedValue([
+        { path: "/repo", branch: "main" },
+        { path: "/repo-worktrees/detached", detached: true },
+      ]),
+    })).list(project);
 
     expect(workspaces.map((workspace) => ({ label: workspace.label, branch: workspace.branch }))).toEqual([
       { label: "main", branch: "main" },
@@ -72,9 +110,11 @@ describe("WorkspaceService.list", () => {
     ]);
   });
 
-  it("returns a single non-git workspace when the project is not a repository", async () => {
-    const service = serviceFor([], false);
+  it("keeps plain directories as a single workspace when neither VCS is detected", async () => {
+    const workspaces = await new WorkspaceService(discovery()).list(project);
 
-    expect(await service.list(project)).toEqual([expect.objectContaining({ path: "/repo", isGitRepo: false, isGitWorktree: false })]);
+    expect(workspaces).toEqual([
+      expect.objectContaining({ path: "/repo", label: "Project", isMain: true, isGitRepo: false, isGitWorktree: false }),
+    ]);
   });
 });

--- a/src/server/workspaces/workspaceService.ts
+++ b/src/server/workspaces/workspaceService.ts
@@ -1,29 +1,42 @@
 import { createHash } from "node:crypto";
-import type { Project } from "../types.js";
-import type { Workspace } from "../types.js";
-import { discoverGitWorktrees, isGitRepository, type GitWorktreeInfo } from "./gitWorktreeDiscovery.js";
+import type { Project, Workspace } from "../types.js";
+import { discoverGitWorkspaceRoot, discoverGitWorktrees, isGitRepository, type GitWorktreeInfo } from "./gitWorktreeDiscovery.js";
+import { discoverJjWorkspaces, isJjRepository, type JjWorkspaceInfo } from "./jjWorkspaceDiscovery.js";
 
 const idFor = (value: string) => createHash("sha1").update(value).digest("hex").slice(0, 12);
 
-/** The git facts this service needs, injectable so workspace policy is testable without a real repo. */
-export interface WorkspaceGitPort {
+export interface WorkspaceDiscovery {
   isGitRepository(path: string): Promise<boolean>;
+  discoverGitWorkspaceRoot(path: string): Promise<string>;
   discoverGitWorktrees(path: string): Promise<GitWorktreeInfo[]>;
+  isJjRepository(path: string): Promise<boolean>;
+  discoverJjWorkspaces(path: string): Promise<JjWorkspaceInfo[]>;
 }
 
-const realGit: WorkspaceGitPort = { isGitRepository, discoverGitWorktrees };
+const defaultDiscovery: WorkspaceDiscovery = {
+  isGitRepository,
+  discoverGitWorkspaceRoot,
+  discoverGitWorktrees,
+  isJjRepository,
+  discoverJjWorkspaces,
+};
 
 export class WorkspaceService {
-  constructor(private readonly git: WorkspaceGitPort = realGit) {}
+  constructor(private readonly discovery: WorkspaceDiscovery = defaultDiscovery) {}
 
   async list(project: Project): Promise<Workspace[]> {
-    const isGitRepo = await this.git.isGitRepository(project.path);
-    if (!isGitRepo) {
-      return [this.single(project, false)];
-    }
+    const isJjRepo = await this.discovery.isJjRepository(project.path);
+    if (isJjRepo) return this.listJjWorkspaces(project);
 
-    const worktrees = this.selectable(await this.git.discoverGitWorktrees(project.path), project);
-    if (worktrees.length === 0) return [this.single(project, true)];
+    const isGitRepo = await this.discovery.isGitRepository(project.path);
+    if (!isGitRepo) return [this.single(project, false)];
+
+    const [discoveredWorktrees, currentRoot] = await Promise.all([
+      this.discovery.discoverGitWorktrees(project.path),
+      this.discovery.discoverGitWorkspaceRoot(project.path),
+    ]);
+    const worktrees = this.selectable(discoveredWorktrees, project);
+    if (worktrees.length === 0) return [this.single(project, true, "git")];
 
     return worktrees.map((worktree) => {
       const leafName = worktree.path.split("/").filter((part) => part !== "").at(-1);
@@ -33,29 +46,46 @@ export class WorkspaceService {
         path: worktree.path,
         label: worktree.branch ?? (worktree.detached === true ? "detached" : leafName ?? worktree.path),
         ...(worktree.branch === undefined ? {} : { branch: worktree.branch }),
-        isMain: worktree.path === project.path,
+        vcs: "git",
+        isMain: worktree.path === currentRoot,
         isGitRepo: true,
         isGitWorktree: true,
       };
     });
   }
 
-  /**
-   * Git keeps listing a linked worktree after its checkout directory is deleted outside PI WEB,
-   * marking it `prunable`. Such an entry is not a usable workspace, so it is hidden rather than
-   * offered as a selectable ghost. Listing stays read-only: we never run `git worktree prune`.
-   * The project's own path is always kept so a project cannot end up with no workspace at all.
-   */
+  /** Hide stale linked worktrees without mutating the repository's worktree metadata. */
   private selectable(worktrees: GitWorktreeInfo[], project: Project): GitWorktreeInfo[] {
     return worktrees.filter((worktree) => worktree.prunable !== true || worktree.path === project.path);
   }
 
-  private single(project: Project, isGitRepo: boolean): Workspace {
+  private async listJjWorkspaces(project: Project): Promise<Workspace[]> {
+    const [workspaces, isGitRepo] = await Promise.all([
+      this.discovery.discoverJjWorkspaces(project.path),
+      this.discovery.isGitRepository(project.path),
+    ]);
+    if (workspaces.length === 0) return [this.single(project, isGitRepo, "jj")];
+
+    return workspaces.map((workspace) => ({
+      id: idFor(`${project.id}:${workspace.path}`),
+      projectId: project.id,
+      path: workspace.path,
+      label: workspace.name,
+      vcs: "jj",
+      vcsWorkspaceName: workspace.name,
+      isMain: workspace.isCurrent,
+      isGitRepo,
+      isGitWorktree: false,
+    }));
+  }
+
+  private single(project: Project, isGitRepo: boolean, vcs?: Workspace["vcs"]): Workspace {
     return {
       id: idFor(`${project.id}:${project.path}`),
       projectId: project.id,
       path: project.path,
       label: project.name,
+      ...(vcs === undefined ? {} : { vcs }),
       isMain: true,
       isGitRepo,
       isGitWorktree: false,

--- a/src/shared/apiTypes.ts
+++ b/src/shared/apiTypes.ts
@@ -187,12 +187,18 @@ export interface WorkspaceEffectiveConfig {
   uploads?: PiWebUploadsConfig;
 }
 
+export type WorkspaceVcs = "git" | "jj";
+
 export interface Workspace {
   id: string;
   projectId: string;
   path: string;
   label: string;
   branch?: string;
+  /** VCS used to discover and manage this workspace. */
+  vcs?: WorkspaceVcs;
+  /** VCS-native workspace name, when it differs from a Git branch. */
+  vcsWorkspaceName?: string;
   isMain: boolean;
   isGitRepo: boolean;
   isGitWorktree: boolean;
@@ -717,6 +723,8 @@ export interface GitStatusFile {
 
 export interface GitStatusResponse {
   isGitRepo: boolean;
+  /** VCS that produced this status. Defaults to Git for legacy responses. */
+  vcs?: WorkspaceVcs;
   hash: string;
   branch?: string;
   upstream?: string;
@@ -732,6 +740,8 @@ export interface GitStatusResponse {
 
 export interface GitDiffResponse {
   path?: string;
+  /** VCS that produced this diff. Defaults to Git for legacy responses. */
+  vcs?: WorkspaceVcs;
   staged: boolean;
   hash: string;
   diff: string;

--- a/src/shared/workspaces.ts
+++ b/src/shared/workspaces.ts
@@ -1,0 +1,6 @@
+import type { Workspace } from "./apiTypes.js";
+
+export function isDeletableWorkspace(workspace: Pick<Workspace, "isMain" | "isGitWorktree" | "vcs" | "vcsWorkspaceName"> | undefined): boolean {
+  if (workspace === undefined || workspace.isMain) return false;
+  return workspace.isGitWorktree || (workspace.vcs === "jj" && workspace.vcsWorkspaceName !== undefined);
+}


### PR DESCRIPTION
Detect Jujutsu workspaces alongside Git worktrees, expose their
status and diffs in the Changes panel, and support safe workspace
deletion.