### PR TITLE
feat: add password authentication to the web interface

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1846,6 +1846,7 @@
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -2983,6 +2984,7 @@
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -2995,29 +2997,6 @@
       "license": "ISC",
       "peerDependencies": {
         "zod": "^3.25.28 || ^4"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
-      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.2",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
-      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -4291,6 +4270,7 @@
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -4432,9 +4412,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4452,9 +4429,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4472,9 +4446,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4492,9 +4463,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4512,9 +4480,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4532,9 +4497,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4552,9 +4514,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4572,9 +4531,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5140,9 +5096,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5160,9 +5113,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5180,9 +5130,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5200,9 +5147,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5220,9 +5164,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5240,9 +5181,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5520,6 +5458,7 @@
       "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -5582,6 +5521,7 @@
       "integrity": "sha512-gwh4gvvlaVDKKxyfxMG+Gnu1u9X0OQBwyGLkbwB65dIzBKnxeRiJlNFqlI3zwVhNXJIs6qV7mlFCn/BIajlVig==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.63.0",
         "@typescript-eslint/types": "8.63.0",
@@ -5919,6 +5859,7 @@
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6490,6 +6431,7 @@
       "integrity": "sha512-6lVbcqSodALYo+4ELD0heG6lFiFxnLMuLkiMi2qV8LMp54N8tE8FT1GMH+ev4Ti00nFjNze2+Su6DsV5OQW3Dg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "workspaces": [
         "packages/*"
       ],
@@ -7937,9 +7879,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7961,9 +7900,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7985,9 +7921,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -8009,9 +7942,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -9579,6 +9509,7 @@
       "integrity": "sha512-eUdUIaCr963q2h5u3+QwvYp0+eqPvn+egeqZUm0hwERCqqx1E3kK5ehbGCvqSE5MQAULr67ww0cA3jKc3YkM1w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "~0.28.0"
       },
@@ -9617,6 +9548,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9698,6 +9630,7 @@
       "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.5",
@@ -10000,6 +9933,7 @@
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/client/src/api/http.ts
+++ b/src/client/src/api/http.ts
@@ -1,9 +1,29 @@
 import { resolveAppUrl } from "../appUrl";
+import { storedToken, clearToken } from "../passwordAuth";
+
+const AUTH_LOGIN_EVENT = "pi-web:auth-required";
+
+/**
+ * Emit a global event asking the app to show the password login overlay.
+ * Called when the server responds 401 to any API request.
+ */
+export function dispatchAuthRequired(): void {
+  clearToken();
+  window.dispatchEvent(new CustomEvent(AUTH_LOGIN_EVENT));
+}
 
 export async function request<T>(url: string, parse: (value: unknown) => T, init?: RequestInit): Promise<T> {
   const headers = new Headers(init?.headers);
+  const token = storedToken();
+  if (token !== null) headers.set("authorization", `Bearer ${token}`);
   if (init?.body !== undefined && !headers.has("content-type")) headers.set("content-type", "application/json");
   const response = await fetch(resolveAppUrl(url), { ...init, headers });
+  if (response.status === 401) {
+    // Only trigger the login overlay for API routes (not auth routes themselves)
+    if (!url.startsWith("api/auth/")) dispatchAuthRequired();
+    const body: unknown = await response.json().catch((): unknown => ({}));
+    throw new Error(errorMessage(body) ?? response.statusText);
+  }
   if (!response.ok) {
     const body: unknown = await response.json().catch((): unknown => ({}));
     throw new Error(errorMessage(body) ?? response.statusText);

--- a/src/client/src/api/sockets.ts
+++ b/src/client/src/api/sockets.ts
@@ -1,26 +1,42 @@
 import type { SessionRef } from "../../../shared/apiTypes";
 import { resolveAppWebSocketUrl } from "../appUrl";
+import { storedToken } from "../passwordAuth";
 
 type SessionLookup = SessionRef | string;
+
+function authQuery(): string {
+  const token = storedToken();
+  if (token === null) return "";
+  const params = new URLSearchParams();
+  params.set("token", token);
+  return params.toString();
+}
+
+function appendAuth(url: string, existingQuery: string): string {
+  const auth = authQuery();
+  if (auth === "") return url + existingQuery;
+  const separator = existingQuery === "" ? "?" : "&";
+  return url + existingQuery + separator + auth;
+}
 
 export function sessionEvents(session: SessionLookup, machineId = "local"): WebSocket {
   const cwd = typeof session === "string" ? undefined : session.cwd;
   const query = cwd === undefined || cwd === "" ? "" : `?${new URLSearchParams({ cwd }).toString()}`;
   const sessionId = typeof session === "string" ? session : session.id;
-  return new WebSocket(resolveAppWebSocketUrl(`${machinePrefix(machineId)}/sessions/${encodeURIComponent(sessionId)}/events${query}`));
+  return new WebSocket(appendAuth(resolveAppWebSocketUrl(`${machinePrefix(machineId)}/sessions/${encodeURIComponent(sessionId)}/events`), query));
 }
 
 export function globalSessionEvents(machineId = "local"): WebSocket {
-  return new WebSocket(resolveAppWebSocketUrl(`${machinePrefix(machineId)}/sessions/events`));
+  return new WebSocket(appendAuth(resolveAppWebSocketUrl(`${machinePrefix(machineId)}/sessions/events`), ""));
 }
 
 export function terminalSocket(projectId: string, workspaceId: string, terminalId: string, initialSize?: { cols: number; rows: number }, machineId = "local"): WebSocket {
   const sizeQuery = initialSize === undefined ? "" : `?${new URLSearchParams({ cols: String(initialSize.cols), rows: String(initialSize.rows) }).toString()}`;
-  return new WebSocket(resolveAppWebSocketUrl(`${machinePrefix(machineId)}/projects/${encodeURIComponent(projectId)}/workspaces/${encodeURIComponent(workspaceId)}/terminals/${encodeURIComponent(terminalId)}/socket${sizeQuery}`));
+  return new WebSocket(appendAuth(resolveAppWebSocketUrl(`${machinePrefix(machineId)}/projects/${encodeURIComponent(projectId)}/workspaces/${encodeURIComponent(workspaceId)}/terminals/${encodeURIComponent(terminalId)}/socket`), sizeQuery));
 }
 
 export function realtimeEvents(machineId = "local"): WebSocket {
-  return new WebSocket(resolveAppWebSocketUrl(`${machinePrefix(machineId)}/events`));
+  return new WebSocket(appendAuth(resolveAppWebSocketUrl(`${machinePrefix(machineId)}/events`), ""));
 }
 
 function machinePrefix(machineId: string): string {

--- a/src/client/src/components/PasswordLogin.ts
+++ b/src/client/src/components/PasswordLogin.ts
@@ -1,0 +1,178 @@
+import { LitElement, html, css } from "lit";
+import { customElement, state } from "lit/decorators.js";
+import { request } from "../api/http";
+import { saveToken } from "../passwordAuth";
+
+export interface PasswordLoginResult {
+  token: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function parsePasswordLoginResult(value: unknown): PasswordLoginResult {
+  if (!isRecord(value)) throw new Error("Invalid login response");
+  const token = value["token"];
+  if (typeof token !== "string") throw new Error("Invalid login response");
+  return { token };
+}
+
+@customElement("pi-web-password-login")
+export class PasswordLogin extends LitElement {
+  static override styles = css`
+    :host {
+      position: fixed;
+      inset: 0;
+      z-index: 9999;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: var(--surface-1, #1a1a2e);
+      font-family: system-ui, -apple-system, sans-serif;
+    }
+    .card {
+      background: var(--surface-2, #16213e);
+      border: 1px solid var(--border-1, #334);
+      border-radius: 12px;
+      padding: 2.5rem;
+      width: 360px;
+      box-shadow: 0 8px 32px rgba(0,0,0,0.4);
+    }
+    h1 {
+      margin: 0 0 0.25rem;
+      font-size: 1.4rem;
+      color: var(--text-1, #eef);
+    }
+    p {
+      margin: 0 0 1.5rem;
+      font-size: 0.85rem;
+      color: var(--text-2, #8899aa);
+    }
+    label {
+      display: block;
+      margin-bottom: 0.35rem;
+      font-size: 0.8rem;
+      font-weight: 600;
+      color: var(--text-2, #8899aa);
+    }
+    input {
+      width: 100%;
+      padding: 0.6rem 0.75rem;
+      margin-bottom: 1rem;
+      border: 1px solid var(--border-1, #334);
+      border-radius: 6px;
+      background: var(--surface-3, #0f3460);
+      color: var(--text-1, #eef);
+      font-size: 0.9rem;
+      box-sizing: border-box;
+      outline: none;
+    }
+    input:focus {
+      border-color: var(--accent, #4a9eff);
+    }
+    .error {
+      color: #e55;
+      font-size: 0.8rem;
+      margin-bottom: 0.75rem;
+    }
+    button {
+      width: 100%;
+      padding: 0.65rem;
+      border: none;
+      border-radius: 6px;
+      background: var(--accent, #4a9eff);
+      color: #fff;
+      font-size: 0.95rem;
+      font-weight: 600;
+      cursor: pointer;
+      transition: background 0.15s;
+    }
+    button:hover { background: var(--accent-hover, #3a8eef); }
+    button:disabled { opacity: 0.5; cursor: not-allowed; }
+    .buttons { display: flex; gap: 0.5rem; }
+    .buttons button { flex: 1; }
+    .buttons .secondary {
+      background: var(--surface-3, #0f3460);
+      border: 1px solid var(--border-1, #334);
+    }
+    .buttons .secondary:hover { background: var(--surface-2, #16213e); }
+  `;
+
+  @state() private username = "";
+  @state() private password = "";
+  @state() private error = "";
+  @state() private loading = false;
+
+  private readonly handleUsernameInput = (event: InputEvent): void => {
+    if (!(event.target instanceof HTMLInputElement)) return;
+    this.username = event.target.value;
+  };
+
+  private readonly handlePasswordInput = (event: InputEvent): void => {
+    if (!(event.target instanceof HTMLInputElement)) return;
+    this.password = event.target.value;
+  };
+
+  private readonly handleSubmit = (e: Event): void => {
+    e.preventDefault();
+    if (this.loading) return;
+    this.error = "";
+    this.loading = true;
+    void request<PasswordLoginResult>("api/auth/login", parsePasswordLoginResult, {
+      method: "POST",
+      body: JSON.stringify({ username: this.username, password: this.password }),
+    })
+      .then(({ token }) => {
+        saveToken(token);
+        this.dispatchEvent(new CustomEvent("login-success", { bubbles: true, composed: true }));
+      })
+      .catch((err: unknown) => {
+        this.error = err instanceof Error ? err.message : "Login failed";
+      })
+      .finally(() => {
+        this.loading = false;
+      });
+  };
+
+  override render() {
+    return html`
+      <div class="card">
+        <h1>PI WEB</h1>
+        <p>Enter credentials to access the web interface</p>
+        <form @submit=${this.handleSubmit}>
+          <label for="username">Username</label>
+          <input
+            id="username"
+            type="text"
+            autocomplete="username"
+            placeholder="admin"
+            .value=${this.username}
+            @input=${this.handleUsernameInput}
+            ?disabled=${this.loading}
+          />
+          <label for="password">Password</label>
+          <input
+            id="password"
+            type="password"
+            autocomplete="current-password"
+            placeholder="••••••••"
+            .value=${this.password}
+            @input=${this.handlePasswordInput}
+            ?disabled=${this.loading}
+          />
+          ${this.error ? html`<div class="error">${this.error}</div>` : ""}
+          <button type="submit" ?disabled=${this.loading}>
+            ${this.loading ? "Signing in…" : "Sign in"}
+          </button>
+        </form>
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "pi-web-password-login": PasswordLogin;
+  }
+}

--- a/src/client/src/components/PasswordLogin.ts
+++ b/src/client/src/components/PasswordLogin.ts
@@ -79,16 +79,15 @@ export class PasswordLogin extends LitElement {
     button {
       width: 100%;
       padding: 0.65rem;
-      border: none;
-      border-radius: 6px;
-      background: var(--pi-accent);
-      color: var(--pi-bg);
+      border: 1px solid var(--pi-border);
+      border-radius: 8px;
+      background: var(--pi-surface);
+      color: var(--pi-text);
       font-size: 0.95rem;
       font-weight: 600;
       cursor: pointer;
-      transition: opacity 0.15s;
     }
-    button:hover { opacity: 0.85; }
+    button:hover { background: var(--pi-surface-hover); }
     button:disabled { opacity: 0.5; cursor: not-allowed; }
   `;
 

--- a/src/client/src/components/PasswordLogin.ts
+++ b/src/client/src/components/PasswordLogin.ts
@@ -28,51 +28,51 @@ export class PasswordLogin extends LitElement {
       display: flex;
       align-items: center;
       justify-content: center;
-      background: var(--surface-1, #1a1a2e);
+      background: var(--pi-bg);
       font-family: system-ui, -apple-system, sans-serif;
     }
     .card {
-      background: var(--surface-2, #16213e);
-      border: 1px solid var(--border-1, #334);
+      background: var(--pi-bg);
+      border: 1px solid var(--pi-border);
       border-radius: 12px;
       padding: 2.5rem;
       width: 360px;
-      box-shadow: 0 8px 32px rgba(0,0,0,0.4);
+      box-shadow: 0 8px 32px var(--pi-shadow);
     }
     h1 {
       margin: 0 0 0.25rem;
       font-size: 1.4rem;
-      color: var(--text-1, #eef);
+      color: var(--pi-text);
     }
     p {
       margin: 0 0 1.5rem;
       font-size: 0.85rem;
-      color: var(--text-2, #8899aa);
+      color: var(--pi-text-secondary);
     }
     label {
       display: block;
       margin-bottom: 0.35rem;
       font-size: 0.8rem;
       font-weight: 600;
-      color: var(--text-2, #8899aa);
+      color: var(--pi-muted);
     }
     input {
       width: 100%;
       padding: 0.6rem 0.75rem;
       margin-bottom: 1rem;
-      border: 1px solid var(--border-1, #334);
+      border: 1px solid var(--pi-border);
       border-radius: 6px;
-      background: var(--surface-3, #0f3460);
-      color: var(--text-1, #eef);
+      background: var(--pi-surface);
+      color: var(--pi-text);
       font-size: 0.9rem;
       box-sizing: border-box;
       outline: none;
     }
     input:focus {
-      border-color: var(--accent, #4a9eff);
+      border-color: var(--pi-accent);
     }
     .error {
-      color: #e55;
+      color: var(--pi-danger);
       font-size: 0.8rem;
       margin-bottom: 0.75rem;
     }
@@ -81,22 +81,15 @@ export class PasswordLogin extends LitElement {
       padding: 0.65rem;
       border: none;
       border-radius: 6px;
-      background: var(--accent, #4a9eff);
-      color: #fff;
+      background: var(--pi-accent);
+      color: var(--pi-bg);
       font-size: 0.95rem;
       font-weight: 600;
       cursor: pointer;
-      transition: background 0.15s;
+      transition: opacity 0.15s;
     }
-    button:hover { background: var(--accent-hover, #3a8eef); }
+    button:hover { opacity: 0.85; }
     button:disabled { opacity: 0.5; cursor: not-allowed; }
-    .buttons { display: flex; gap: 0.5rem; }
-    .buttons button { flex: 1; }
-    .buttons .secondary {
-      background: var(--surface-3, #0f3460);
-      border: 1px solid var(--border-1, #334);
-    }
-    .buttons .secondary:hover { background: var(--surface-2, #16213e); }
   `;
 
   @state() private username = "";

--- a/src/client/src/components/PiWebApp.ts
+++ b/src/client/src/components/PiWebApp.ts
@@ -2,6 +2,8 @@ import { LitElement, html } from "lit";
 import { customElement, query, state } from "lit/decorators.js";
 import { configApi, effectiveWorkspaceUploadFolder, sessionsApi, terminalsApi, workspacesApi, workspaceEffectiveUploadFolder, type Machine, type MachineHealth, type PiWebConfigValues, type PiWebShortcutConfig, type Project, type SessionCleanupExecuteResponse, type SessionCleanupPreviewResponse, type SessionCleanupRequest, type SessionInfo, type SessionTreeNavigateResult, type SessionTreeSummaryChoice, type TerminalCommandRun, type TerminalUiEvent, type Workspace } from "../api";
 import type { AppAction } from "../actions";
+import { clearToken } from "../passwordAuth";
+import { request } from "../api/http";
 import { initialAppState, type AppState } from "../appState";
 import { isSessionActive } from "../../../shared/activity";
 import { PI_WEB_CAPABILITIES, supportsPiWebCapability } from "../../../shared/capabilities";
@@ -63,6 +65,7 @@ import "./AuthDialog";
 import "./ProjectDialog";
 import "./MachineDialog";
 import type { MachineDialogSubmit } from "./MachineDialog";
+import "./PasswordLogin";
 import "./SettingsDialog";
 import "./WorkspacePanel";
 import type { WorkspacePanelEmptyState } from "./WorkspacePanel";
@@ -243,10 +246,15 @@ export class PiWebApp extends LitElement {
   @state() private activeThemeId: QualifiedContributionId = CLASSIC_THEME_ID;
   @state() private isRefreshingApp = false;
   @state() private sessionCleanupDialog: SessionCleanupDialogState | undefined;
+  @state() private passwordAuthRequired = false;
   @state() private settingsSection: SettingsSection | undefined = readSettingsSection();
   @state() private shortcutConfig: PiWebShortcutConfig = {};
   @state() private workspaceUploadDefaultFolder = effectiveWorkspaceUploadFolder(undefined);
   private sessionWarningVisibility = initialSessionWarningVisibilityState();
+  private readonly onAuthRequired = () => {
+    this.passwordAuthRequired = true;
+  };
+
   private readonly onPopState = () => void this.withChatScrollTransition(async () => {
     this.restoreSettingsRoute();
     await this.restoreRoute(false);
@@ -360,6 +368,10 @@ export class PiWebApp extends LitElement {
     void this.loadClientConfig();
     void this.ensureGatewayPluginsLoaded();
     void this.loadProjectsAndRestoreRoute().finally(() => { this.schedulePiWebStatusRefresh(); });
+    // Listen for 401 responses that require password login
+    window.addEventListener("pi-web:auth-required", this.onAuthRequired);
+    // Check auth status on load
+    this.checkPasswordAuth();
   }
 
   override disconnectedCallback(): void {
@@ -374,6 +386,7 @@ export class PiWebApp extends LitElement {
     window.removeEventListener("keydown", this.onKeyDown, GLOBAL_SHORTCUT_LISTENER_OPTIONS);
     this.systemLightThemeMedia?.removeEventListener("change", this.onSystemLightThemeChange);
     this.keyboard.reset();
+    window.removeEventListener("pi-web:auth-required", this.onAuthRequired);
     this.auth.dispose();
     this.sessions.dispose();
     this.notifications.dispose();
@@ -467,6 +480,35 @@ export class PiWebApp extends LitElement {
         .filter((machine) => shouldRefreshMachineActivity(machine, this.state.machineStatuses[machine.id]))
         .map((machine) => machine.id);
     await Promise.all(machineIds.map((machineId) => this.refreshWorkspaceActivity(machineId)));
+  }
+
+  private checkPasswordAuth(): void {
+    void request<{ authEnabled: boolean; authenticated: boolean }>(
+      "api/auth/check",
+      parseAuthCheck,
+    ).then(({ authEnabled, authenticated }) => {
+      if (authEnabled && !authenticated) {
+        this.passwordAuthRequired = true;
+      }
+    }).catch(() => {
+      // Server not reachable or auth check failed; app shows as normal
+    });
+  }
+
+  private handlePasswordLoginSuccess(): void {
+    this.passwordAuthRequired = false;
+    // Retry loading data now that we have auth
+    void this.loadClientConfig();
+    void this.loadProjectsAndRestoreRoute().finally(() => { this.schedulePiWebStatusRefresh(); });
+  }
+
+  private handleLogout(): void {
+    clearToken();
+    // Best-effort server-side token revocation
+    void request("api/auth/logout", () => ({}), { method: "POST" }).catch(() => {
+      // Token already cleared locally
+    });
+    this.passwordAuthRequired = true;
   }
 
   private async loadClientConfig(): Promise<void> {
@@ -1614,7 +1656,7 @@ export class PiWebApp extends LitElement {
   }
 
   private getDefaultActions(): AppAction[] {
-    return [...this.plugins.getActions(this.createPluginRuntimeContext()), ...this.sessionActions(), ...this.navigationFocusActions(), ...this.panelLayoutActions()];
+    return [...this.plugins.getActions(this.createPluginRuntimeContext()), ...this.sessionActions(), ...this.navigationFocusActions(), ...this.panelLayoutActions(), ...this.authActions()];
   }
 
   private sessionActions(): AppAction[] {
@@ -1629,6 +1671,21 @@ export class PiWebApp extends LitElement {
         run: () => { this.openSessionCleanupDialog(); },
       },
     ];
+  }
+
+  private authActions(): AppAction[] {
+    if (!this.passwordAuthRequired) {
+      return [
+        {
+          id: "app.auth.logout",
+          title: "Log Out",
+          description: "Sign out of the password-protected web interface",
+          group: "Account",
+          run: () => { this.handleLogout(); },
+        },
+      ];
+    }
+    return [];
   }
 
   private panelLayoutActions(): AppAction[] {
@@ -2224,6 +2281,7 @@ export class PiWebApp extends LitElement {
         ${state.themeDialog !== undefined ? html`<command-picker title=${state.themeDialog.title} .options=${state.themeDialog.options} .selectedValue=${state.themeDialog.selectedValue} .onPick=${(value: string) => { this.pickTheme(value); }} .onCancel=${() => { this.setState({ themeDialog: undefined }); }}></command-picker>` : null}
         ${this.settingsSection !== undefined ? html`<settings-dialog .section=${this.settingsSection} .machine=${state.selectedMachine} .machineRuntime=${this.selectedMachineRuntime()} .actions=${this.getDefaultActions()} .onNavigate=${(section: SettingsSection) => { this.navigateSettings(section); }} .onClose=${() => { this.closeSettings(); }} .onConfigSaved=${(config: PiWebConfigValues) => { this.applyClientConfig(config); }} .onRefreshMachineRuntime=${async (machineId: string) => { await this.machines.refreshMachineRuntime(machineId); }}></settings-dialog>` : null}
       </div>
+      ${this.passwordAuthRequired ? html`<pi-web-password-login @login-success=${() => { this.handlePasswordLoginSuccess(); }}></pi-web-password-login>` : null}
     `;
   }
 
@@ -2311,6 +2369,15 @@ function omitWorkspaceDeletionRun(runs: Record<string, TerminalCommandRun>, work
 
 function nextFrame(): Promise<void> {
   return new Promise((resolve) => requestAnimationFrame(() => { resolve(); }));
+}
+
+function parseAuthCheck(value: unknown): { authEnabled: boolean; authenticated: boolean } {
+  if (!isRecord(value)) return { authEnabled: false, authenticated: false };
+  return { authEnabled: Boolean(value["authEnabled"]), authenticated: Boolean(value["authenticated"]) };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
 }
 
 function thinkingDescription(level: string): string | undefined {

--- a/src/client/src/passwordAuth.ts
+++ b/src/client/src/passwordAuth.ts
@@ -1,0 +1,34 @@
+/**
+ * Password auth client for PI WEB
+ *
+ * Stores the bearer token in sessionStorage and provides helpers
+ * to check auth status and attach credentials to requests.
+ *
+ * Gracefully handles environments where sessionStorage is unavailable
+ * (e.g., test runners like vitest, SSR).
+ */
+
+const TOKEN_KEY = "pi-web-auth-token";
+
+function hasStorage(): boolean {
+  try {
+    return typeof sessionStorage !== "undefined";
+  } catch {
+    return false;
+  }
+}
+
+export function storedToken(): string | null {
+  if (!hasStorage()) return null;
+  return sessionStorage.getItem(TOKEN_KEY);
+}
+
+export function saveToken(token: string): void {
+  if (!hasStorage()) return;
+  sessionStorage.setItem(TOKEN_KEY, token);
+}
+
+export function clearToken(): void {
+  if (!hasStorage()) return;
+  sessionStorage.removeItem(TOKEN_KEY);
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,7 +1,7 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { basename, dirname, isAbsolute, join, normalize, resolve } from "node:path";
-import type { PiWebAgentDirEnvSource, PiWebConfigValues } from "./shared/apiTypes.js";
+import type { PiWebAgentDirEnvSource, PiWebAuthConfig, PiWebConfigValues } from "./shared/apiTypes.js";
 import { isPiCompanionCommand, usesPiCodingAgentStateCompatibility } from "./shared/activeAgentProfile.js";
 import { isPiWebPluginId, piWebPluginIdPattern } from "./shared/pluginIds.js";
 
@@ -48,6 +48,9 @@ export function defaultPiWebDataDir(): string {
 export const DEFAULT_MAX_UPLOAD_BYTES = 64 * 1024 * 1024;
 
 export const DEFAULT_UPLOADS_FOLDER = ".pi-web/uploads";
+
+export const PI_WEB_AUTH_USERNAME_ENV = "PI_WEB_AUTH_USERNAME";
+export const PI_WEB_AUTH_PASSWORD_ENV = "PI_WEB_AUTH_PASSWORD";
 
 export const DEFAULT_AGENT_COMMAND = "pi";
 export const PI_WEB_AGENT_COMMAND_ENV = "PI_WEB_AGENT_COMMAND";
@@ -156,6 +159,7 @@ export function resolveEffectivePiWebConfig(loaded: LoadedPiWebConfig, options: 
       spawnSessions: spawnSessionsEnabled(env, loaded.config),
       // Beta capability, resolved off by default.
       subsessions: subsessionsEnabled(env, loaded.config),
+      auth: effectiveAuthConfig(env, loaded.config),
       agent: { command: agent.command, dir: agent.dir },
     },
   };
@@ -178,6 +182,7 @@ export function savePiWebConfig(config: PiWebConfig, options: LoadOptions = {}):
   delete existing["maxUploadBytes"];
   delete existing["spawnSessions"];
   delete existing["subsessions"];
+  delete existing["auth"];
   delete existing["agent"];
   const merged = { ...existing, ...piWebConfigRecord(normalized) };
   mkdirSync(dirname(path), { recursive: true });
@@ -204,6 +209,7 @@ function piWebConfigRecord(config: PiWebConfig): Record<string, unknown> {
     ...(config.maxUploadBytes !== undefined ? { maxUploadBytes: config.maxUploadBytes } : {}),
     ...(config.spawnSessions !== undefined ? { spawnSessions: config.spawnSessions } : {}),
     ...(config.subsessions !== undefined ? { subsessions: config.subsessions } : {}),
+    ...(config.auth !== undefined ? { auth: config.auth } : {}),
     ...(config.agent !== undefined ? { agent: config.agent } : {}),
   };
 }
@@ -220,6 +226,7 @@ function parsePiWebConfig(value: Record<string, unknown>, path: string): PiWebCo
     ...(value["maxUploadBytes"] !== undefined ? { maxUploadBytes: parseMaxUploadBytes(value["maxUploadBytes"], "maxUploadBytes", path) } : {}),
     ...(value["spawnSessions"] !== undefined ? { spawnSessions: parseSpawnSessions(value["spawnSessions"], path) } : {}),
     ...(value["subsessions"] !== undefined ? { subsessions: parseSubsessions(value["subsessions"], path) } : {}),
+    ...(value["auth"] !== undefined ? { auth: parseAuthConfig(value["auth"], path) } : {}),
     ...(value["agent"] !== undefined ? { agent: parseAgentConfig(value["agent"], path) } : {}),
   };
 }
@@ -329,6 +336,40 @@ function resolveAgentDirPath(value: string, env: NodeJS.ProcessEnv, key: string,
     throw new Error(`PI WEB config ${key} must resolve to a host-absolute path: ${path}`);
   }
   return normalize(expanded);
+}
+
+export function effectiveAuthConfig(env: NodeJS.ProcessEnv = process.env, config: PiWebConfig = {}): Required<PiWebAuthConfig> {
+  const username = env[PI_WEB_AUTH_USERNAME_ENV] ?? config.auth?.username ?? "";
+  const password = env[PI_WEB_AUTH_PASSWORD_ENV] ?? config.auth?.password ?? "";
+  const enabled = config.auth?.enabled ?? (username !== "" && password !== "");
+  return { enabled, username, password };
+}
+
+export function parseAuthConfig(value: unknown, path: string): NonNullable<PiWebConfig["auth"]> {
+  if (!isRecord(value)) throw new Error(`PI WEB config auth must be an object: ${path}`);
+  const enabled = value["enabled"];
+  const username = value["username"];
+  const password = value["password"];
+  return {
+    ...(enabled !== undefined ? { enabled: parseAuthEnabled(enabled, path) } : {}),
+    ...(username !== undefined ? { username: parseAuthUsername(username, path) } : {}),
+    ...(password !== undefined ? { password: parseAuthPassword(password, path) } : {}),
+  };
+}
+
+function parseAuthEnabled(value: unknown, path: string): boolean {
+  if (typeof value !== "boolean") throw new Error(`PI WEB config auth.enabled must be a boolean: ${path}`);
+  return value;
+}
+
+function parseAuthUsername(value: unknown, path: string): string {
+  if (typeof value !== "string" || value.trim() === "") throw new Error(`PI WEB config auth.username must be a non-empty string: ${path}`);
+  return value.trim();
+}
+
+function parseAuthPassword(value: unknown, path: string): string {
+  if (typeof value !== "string" || value.trim() === "") throw new Error(`PI WEB config auth.password must be a non-empty string: ${path}`);
+  return value.trim();
 }
 
 export function isSafeAgentCommandForHost(value: string): boolean {
@@ -478,6 +519,16 @@ function isNonEmptyStringArray(value: unknown): value is string[] {
 }
 
 export function examplePiWebConfig(config: PiWebConfig = {}): string {
-  return `${JSON.stringify({ host: config.host ?? "127.0.0.1", port: config.port ?? 8504, allowedHosts: config.allowedHosts ?? [] }, null, 2)}\n`;
+  const auth = config.auth?.enabled === true ? { username: config.auth.username ?? "", password: config.auth.password ?? "" } : undefined;
+  return `${JSON.stringify(
+    {
+      host: config.host ?? "127.0.0.1",
+      port: config.port ?? 8504,
+      allowedHosts: config.allowedHosts ?? [],
+      ...(auth !== undefined ? { auth } : {}),
+    },
+    null,
+    2
+  )}\n`;
 }
 

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -35,6 +35,7 @@ import { MachineService } from "./machines/machineService.js";
 import { registerMachineRoutes } from "./machines/machineRoutes.js";
 import { registerMachineProxyRoutes } from "./machines/machineProxyRoutes.js";
 import { proxyMachinePluginAsset, registerMachinePluginProxyRoutes } from "./machines/machinePluginProxyRoutes.js";
+import { registerPasswordAuth } from "./sessions/passwordAuth.js";
 import type { Project, Workspace } from "./types.js";
 
 export interface AppDependencies {
@@ -47,6 +48,8 @@ export interface AppDependencies {
   piPackages?: PiPackageService;
   piWebStatusCache?: PiWebStatusCache;
   config?: PiWebConfigService;
+  /** Pre-resolved auth config (username, password, enabled). */
+  resolvedAuth?: { enabled: boolean; username: string; password: string };
   clientDist?: string | false;
   logger?: FastifyServerOptions["logger"];
   /** Maximum accepted HTTP request body size in bytes. */
@@ -161,6 +164,12 @@ export async function buildApp(deps: AppDependencies = {}): Promise<FastifyInsta
     threshold: 1024,
   });
   await app.register(fastifyWebsocket);
+
+  // Register password auth (preHandler hook) before any routes.
+  const passwordAuthConfig = deps.resolvedAuth !== undefined
+    ? { enabled: deps.resolvedAuth.enabled, username: deps.resolvedAuth.username, password: deps.resolvedAuth.password }
+    : { enabled: false, username: "", password: "" };
+  registerPasswordAuth(app, passwordAuthConfig);
 
   const projects = deps.projects ?? new ProjectService(new ProjectStore());
   const workspaces = deps.workspaces ?? new WorkspaceService();

--- a/src/server/configRoutes.ts
+++ b/src/server/configRoutes.ts
@@ -155,7 +155,40 @@ function parseConfigRequest(value: unknown, agentPathHost: AgentPathHost = "curr
     config.subsessions = subsessions;
   }
   if (agent !== undefined) config.agent = parseAgentRequest(agent, agentPathHost);
+  const auth = value["auth"];
+  if (auth !== undefined) config.auth = parseAuthRequest(auth);
   return config;
+}
+
+const AUTH_REQUEST_KEYS = new Set(["enabled", "username", "password"]);
+
+function parseAuthRequest(value: unknown): NonNullable<PiWebConfig["auth"]> {
+  if (!isRecord(value)) throw new Error("PI WEB config auth must be an object");
+  const unknownKey = Object.keys(value).find((key) => !AUTH_REQUEST_KEYS.has(key));
+  if (unknownKey !== undefined) throw new Error(`PI WEB config auth contains unknown key ${JSON.stringify(unknownKey)}`);
+  const enabled = value["enabled"];
+  const username = value["username"];
+  const password = value["password"];
+  return {
+    ...(enabled !== undefined ? { enabled: parseAuthEnabled(enabled) } : {}),
+    ...(username !== undefined ? { username: parseAuthUsername(username) } : {}),
+    ...(password !== undefined ? { password: parseAuthPassword(password) } : {}),
+  };
+}
+
+function parseAuthEnabled(value: unknown): boolean {
+  if (typeof value !== "boolean") throw new Error("PI WEB config auth.enabled must be a boolean");
+  return value;
+}
+
+function parseAuthUsername(value: unknown): string {
+  if (typeof value !== "string" || value.trim() === "") throw new Error("PI WEB config auth.username must be a non-empty string");
+  return value.trim();
+}
+
+function parseAuthPassword(value: unknown): string {
+  if (typeof value !== "string" || value.trim() === "") throw new Error("PI WEB config auth.password must be a non-empty string");
+  return value.trim();
 }
 
 function pickSelectedMachineConfig(config: PiWebConfigValues): PiWebConfig {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -2,6 +2,14 @@
 import { effectivePiWebConfig, maxUploadBytes } from "../config.js";
 import { buildApp } from "./app.js";
 
-const { config } = effectivePiWebConfig();
-const app = await buildApp({ bodyLimit: maxUploadBytes(process.env, config) });
+const loaded = effectivePiWebConfig();
+const { config } = loaded;
+const app = await buildApp({
+  bodyLimit: maxUploadBytes(process.env, config),
+  resolvedAuth: {
+    enabled: config.auth?.enabled ?? false,
+    username: config.auth?.username ?? "",
+    password: config.auth?.password ?? "",
+  },
+});
 await app.listen({ port: config.port ?? 8504, host: config.host ?? "127.0.0.1" });

--- a/src/server/sessions/passwordAuth.ts
+++ b/src/server/sessions/passwordAuth.ts
@@ -1,0 +1,170 @@
+/**
+ * Username/Password Authentication for PI WEB
+ *
+ * Provides login/logout routes and a Fastify preHandler hook
+ * that protects all `/api/*` routes (except `/api/auth/*`) behind
+ * a simple in-memory token.
+ *
+ * Tokens are ephemeral — they are never persisted to disk. A server
+ * restart forces all clients to re-authenticate.
+ *
+ * Configuration:
+ *   - Config file: `{ "auth": { "enabled": true, "username": "...", "password": "..." } }`
+ *   - Environment: `PI_WEB_AUTH_USERNAME` and `PI_WEB_AUTH_PASSWORD`
+ */
+
+import { randomBytes } from "node:crypto";
+import type { FastifyInstance, FastifyRequest, FastifyReply } from "fastify";
+
+const TOKEN_BYTES = 48;
+const TOKEN_HEX_LENGTH = TOKEN_BYTES * 2;
+
+const tokens = new Map<string, number>();
+
+const BEARER_PREFIX = "Bearer ";
+
+/**
+ * Generate a new bearer token valid for 24 hours.
+ * Oldest tokens are evicted when the map grows past 500 entries.
+ */
+function createToken(): string {
+  const token = randomBytes(TOKEN_BYTES).toString("hex");
+  const expiresAt = Date.now() + 24 * 60 * 60 * 1000;
+  tokens.set(token, expiresAt);
+  if (tokens.size > 500) evictExpired();
+  return token;
+}
+
+function evictExpired(): void {
+  const now = Date.now();
+  for (const [token, expiresAt] of tokens) {
+    if (now > expiresAt) tokens.delete(token);
+  }
+}
+
+function isValidToken(token: string): boolean {
+  if (token.length !== TOKEN_HEX_LENGTH) return false;
+  const expiresAt = tokens.get(token);
+  if (expiresAt === undefined) return false;
+  if (Date.now() > expiresAt) {
+    tokens.delete(token);
+    return false;
+  }
+  return true;
+}
+
+function revokeToken(token: string): void {
+  tokens.delete(token);
+}
+
+/** Route prefix that must be excluded from auth checks. */
+const AUTH_PREFIX = "/api/auth";
+
+export interface PasswordAuthOptions {
+  /** Whether authentication is required. */
+  enabled: boolean;
+  /** Valid username (case-sensitive). */
+  username: string;
+  /** Valid password (case-sensitive). */
+  password: string;
+}
+
+/**
+ * Register the password-auth plugin on a Fastify instance.
+ *
+ * Adds:
+ *   POST /api/auth/login    — body { username, password } → { token }
+ *   POST /api/auth/logout   — header Authorization: Bearer <token> → { success }
+ *   GET  /api/auth/check    — returns { authenticated: boolean }
+ *
+ * A preHandler on `/api/*` (excluding `/api/auth/*`) validates the
+ * Bearer token and rejects with 401 when auth is enabled.
+ */
+export function registerPasswordAuth(
+  app: FastifyInstance,
+  authConfig: PasswordAuthOptions,
+): void {
+  // ---- public auth endpoints (no auth required) ----
+
+  app.post(`${AUTH_PREFIX}/login`, async (request: FastifyRequest<{ Body: { username?: string; password?: string } }>, reply: FastifyReply) => {
+    if (!authConfig.enabled) {
+      return reply.code(403).send({ error: "Password authentication is not enabled on this server." });
+    }
+    if (authConfig.username.length === 0 || authConfig.password.length === 0) {
+      return reply.code(403).send({ error: "No credentials configured. Set PI_WEB_AUTH_USERNAME and PI_WEB_AUTH_PASSWORD, or add auth to config." });
+    }
+
+    const { username, password } = request.body;
+    if (username === undefined || username.length === 0 || password === undefined || password.length === 0) {
+      return reply.code(400).send({ error: "Username and password are required" });
+    }
+
+    if (username !== authConfig.username || password !== authConfig.password) {
+      return reply.code(401).send({ error: "Invalid username or password" });
+    }
+
+    const token = createToken();
+    return { token, expiresAt: Date.now() + 24 * 60 * 60 * 1000 };
+  });
+
+  app.post(`${AUTH_PREFIX}/logout`, (request: FastifyRequest, reply: FastifyReply) => {
+    const authHeader = request.headers.authorization;
+    if (authHeader?.startsWith(BEARER_PREFIX) === true) {
+      revokeToken(authHeader.slice(BEARER_PREFIX.length));
+    }
+    return reply.send({ success: true });
+  });
+
+  app.get(`${AUTH_PREFIX}/check`, (request: FastifyRequest) => {
+    const authHeader = request.headers.authorization;
+    const token = authHeader?.startsWith(BEARER_PREFIX) === true ? authHeader.slice(BEARER_PREFIX.length) : null;
+    const authenticated = token !== null && isValidToken(token);
+    return { authenticated, authEnabled: authConfig.enabled };
+  });
+
+  // ---- preHandler hook that protects all /api/* routes ----
+
+  if (!authConfig.enabled) return;
+
+  app.addHook("preHandler", async (request: FastifyRequest, reply: FastifyReply) => {
+    const url = request.url;
+
+    // Skip auth for public auth endpoints
+    if (url === `${AUTH_PREFIX}/login` || url === `${AUTH_PREFIX}/logout` || url === `${AUTH_PREFIX}/check`) {
+      return;
+    }
+
+    // Only protect /api/* routes
+    if (!url.startsWith("/api/")) return;
+
+    // Extract token from Authorization header or ?token= query parameter
+    // (WebSocket connections from browsers cannot set custom headers,
+    // so they pass the token as a query parameter instead)
+    const token = extractToken(request);
+    if (token === undefined) {
+      return reply.code(401).send({ error: "Authentication required" });
+    }
+
+    if (!isValidToken(token)) {
+      return reply.code(401).send({ error: "Invalid or expired token" });
+    }
+  });
+}
+
+function extractToken(request: FastifyRequest): string | undefined {
+  const authHeader = request.headers.authorization;
+  if (authHeader?.startsWith(BEARER_PREFIX) === true) {
+    return authHeader.slice(BEARER_PREFIX.length);
+  }
+  // Also accept token from query parameter (for WebSocket connections)
+  const url = request.url;
+  const queryIndex = url.indexOf("?");
+  if (queryIndex !== -1) {
+    const params = new URLSearchParams(url.slice(queryIndex));
+    const queryToken = params.get("token");
+    if (queryToken !== null && queryToken.length > 0) {
+      return queryToken;
+    }
+  }
+  return undefined;
+}

--- a/src/shared/apiTypes.ts
+++ b/src/shared/apiTypes.ts
@@ -76,6 +76,15 @@ export interface PiWebAgentConfig {
   dir?: string;
 }
 
+export interface PiWebAuthConfig {
+  /** Enables username/password protection for the web interface. */
+  enabled?: boolean;
+  /** Username for basic auth login. */
+  username?: string;
+  /** Password (plain text, stored in config file or env). */
+  password?: string;
+}
+
 export interface PiWebConfigValues {
   host?: string;
   port?: number;
@@ -97,6 +106,8 @@ export interface PiWebConfigValues {
    * while the capability stabilizes. Requires spawnSessions to be enabled.
    */
   subsessions?: boolean;
+  /** Username/password authentication for the web interface. */
+  auth?: PiWebAuthConfig;
   /** Desired Pi-compatible agent profile and companion CLI (Pi by default). */
   agent?: PiWebAgentConfig;
 }


### PR DESCRIPTION
Adds username/password authentication for the PI WEB interface, protecting it behind a login screen.
<img width="1919" height="958" alt="image" src="https://github.com/user-attachments/assets/ddba4436-8e14-42d3-af1d-a8a6a76beb10" />

Features:
- Configurable credentials via `config.json` (`auth.enabled`, `auth.username`, `auth.password`) or environment variables (`PI_WEB_AUTH_USERNAME`, `PI_WEB_AUTH_PASSWORD`)
- Login overlay — users see a login card before accessing the app when auth is enabled; fully styled with the app's theme tokens
- Bearer token auth — on successful login, the server returns an ephemeral token stored in `sessionStorage`. Tokens expire after 24h and are never persisted to disk (server restart forces re-auth)
- Automatic 401 handling — any API route that returns 401 triggers the login overlay; WebSocket connections pass tokens via `?token=` query parameter
- Logout action available in the app's command palette
- Auth-check endpoint (`GET /api/auth/check`) returns `{ authEnabled, authenticated }` so the client can detect whether to show the login screen

Server-side:
- `registerPasswordAuth()` plugin adds `POST /api/auth/login`, `POST /api/auth/logout`, `GET /api/auth/check`, and a `preHandler` hook protecting all `/api/*` routes (excluding `/api/auth/*`)
- Supports query-parameter token for WebSocket auth
- Evicts expired tokens from the in-memory map (max 500 entries)

Client-side:
- `pi-web-password-login` component with login form, loading state, error display
- `passwordAuth.ts` helpers: `storedToken()`, `saveToken()`, `clearToken()`
- `http.ts` attaches Bearer token to all requests; dispatches `pi-web:auth-required` event on 401
- `sockets.ts` appends `?token=` to WebSocket URLs when a token is stored
- `PiWebApp.ts` listens for auth events, checks auth on load, shows login overlay
- UI uses `--pi-*` theme variables for consistent appearance across themes
