### PR TITLE
test(sessions): fix Windows-only failures from drive-relative fixture paths

### DIFF
--- a/src/server/sessions/parentSessionLocator.test.ts
+++ b/src/server/sessions/parentSessionLocator.test.ts
@@ -1,10 +1,13 @@
+import { resolve } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { countOutOfListingChildren, locateOutOfListingParents } from "./parentSessionLocator.js";
 import type { SessionHeaderSummary } from "./sessionFileHeader.js";
 
 const PARENT_PATH = "/sessions/--srv-other--/parent.jsonl";
 const LISTING_CWD = "/srv/dev/pi-web";
-const PARENT_CWD = "/srv/other-worktree";
+// Resolved because the locator canonicalizes header cwds: a bare "/srv/..." is
+// drive-relative on Windows and would land on the runner's current drive.
+const PARENT_CWD = resolve("/srv/other-worktree");
 
 describe("locateOutOfListingParents", () => {
   it("reports the cwd and id of a parent that is not in the listing", async () => {

--- a/src/server/sessions/piSessionService.crossWorkspace.test.ts
+++ b/src/server/sessions/piSessionService.crossWorkspace.test.ts
@@ -1,13 +1,16 @@
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { PiSessionService, type PiSessionListEntry } from "./piSessionService.js";
 import { CapturingSessionEventHub, emptyArchiveStore, fakeSessionManager, sessionRecord, testModelRuntime, type SessionGateway } from "./piSessionService.testSupport.js";
 
 const TEST_AGENT_DIR = "/tmp/pi-web-test-agent";
 const CHILD_CWD = "/srv/dev/pi-web";
-const PARENT_CWD = "/srv/dev/pi-web-feature";
+// Resolved because the service canonicalizes header cwds before annotating: a
+// bare "/srv/..." is drive-relative on Windows and would land on the runner's
+// current drive.
+const PARENT_CWD = resolve("/srv/dev/pi-web-feature");
 
 let tempDir: string;
 

--- a/src/server/sessions/piSessionService.unread.test.ts
+++ b/src/server/sessions/piSessionService.unread.test.ts
@@ -694,9 +694,13 @@ describe("PiSessionService daemon-owned unread state", () => {
 
   it("clears unread for sessions archived and deleted by cleanup", async () => {
     const unreadStore = new SessionUnreadStore({ createCatalogId: () => "catalog-test" });
-    completeStoreWork(unreadStore, "cleanup-archive", "/old-project");
-    completeStoreWork(unreadStore, "cleanup-delete", "/old-project");
-    const archivedRecord = { sessionId: "cleanup-delete", cwd: "/old-project", archivedAt: "2026-04-01T00:00:00.000Z", archivePath: "/archive/cleanup-delete.jsonl" };
+    // Resolved because the service canonicalizes cwds before forgetting unread:
+    // a bare "/old-project" is drive-relative on Windows and would land on the
+    // runner's current drive, so the seeded marker would never match.
+    const oldProjectCwd = resolve("/old-project");
+    completeStoreWork(unreadStore, "cleanup-archive", oldProjectCwd);
+    completeStoreWork(unreadStore, "cleanup-delete", oldProjectCwd);
+    const archivedRecord = { sessionId: "cleanup-delete", cwd: oldProjectCwd, archivedAt: "2026-04-01T00:00:00.000Z", archivePath: "/archive/cleanup-delete.jsonl" };
     const service = new PiSessionService(new CapturingSessionEventHub(), {
       agentDir: TEST_AGENT_DIR,
       modelRuntime: testModelRuntime,
@@ -705,7 +709,7 @@ describe("PiSessionService daemon-owned unread state", () => {
       sessionManager: {
         create: () => fakeSessionManager(),
         list: () => Promise.resolve([]),
-        listAll: () => Promise.resolve([sessionRecord("cleanup-archive", "/old-project")]),
+        listAll: () => Promise.resolve([sessionRecord("cleanup-archive", oldProjectCwd)]),
         open: () => fakeSessionManager(),
       },
       archiveStore: {


### PR DESCRIPTION
## What

Fixes the 5 Windows-runner failures currently keeping `main`'s CI red:

- `parentSessionLocator.test.ts` — "reports the cwd and id of a parent that is not in the listing"
- `piSessionService.crossWorkspace.test.ts` — 3 tests asserting `parentSessionCwd`
- `piSessionService.unread.test.ts` — "clears unread for sessions archived and deleted by cleanup"

(the cross-workspace ones came with `69b125b`; the unread one has been red on Windows since before it — yesterday's `gitService` submodule failures visible in older runs were fixed separately and no longer appear.)

## Root cause

Test bug, not production behavior. The fixtures used bare POSIX-absolute paths (`/srv/other-worktree`, `/old-project`). `win32` treats those as absolute but **drive-relative**, so `resolve()` maps them onto the runner's current drive (`D:\srv\other-worktree`). The code under test canonicalizes stored cwds by contract (`canonicalizeStoredCwd`), so on Windows the produced values never equaled the raw fixture strings — and the cleanup test's seeded unread marker (keyed by the raw cwd) never matched the canonicalized forget. On Linux everything resolved to itself and the tests passed.

## Fix

Resolve the fixture paths once at declaration (`resolve("/srv/other-worktree")` etc.), matching the file's existing `WORKSPACE_CWD = resolve("/workspace")` convention, so fixtures model what a real Windows Pi would record. Test-only change; Linux behavior is unchanged (41/41 in the touched files, full `npm run verify` green locally).

No changeset: test-only change, nothing user-facing ships.