### PR TITLE
fix(client): keep chat composer clear of Android gesture bar in standalone PWA

### DIFF
--- a/.changeset/android-pwa-bottom-safe-area.md
+++ b/.changeset/android-pwa-bottom-safe-area.md
@@ -1,0 +1,5 @@
+---
+"@jmfederico/pi-web": patch
+---
+
+Fix the chat composer (model picker and send button) being clipped at the bottom of the screen on Android standalone PWAs. The app reserves `env(safe-area-inset-bottom)` for the bottom safe area in standalone display modes, but on Android (Chromium edge-to-edge) that inset often resolves to `0` in the standalone WebView even though the gesture navigation bar overlaps content, so the bottom controls render behind it. Floor the reserved space with `max(env(safe-area-inset-bottom, 0px), 20px)` so the composer always clears the gesture bar; devices that report a real inset (e.g. the iOS home indicator) keep using it.

--- a/src/client/src/components/shared.ts
+++ b/src/client/src/components/shared.ts
@@ -86,9 +86,10 @@ export interface CompletionItem {
 export const appStyles = css`
   /* Mobile browsers already subtract browser controls from 100dvh; reserve bottom safe area only in standalone PWA modes. */
   :host { --pi-app-safe-area-bottom: 0px; position: fixed; top: 0; right: 0; left: 0; display: block; height: 100dvh; box-sizing: border-box; overflow: hidden; padding: env(safe-area-inset-top) env(safe-area-inset-right) var(--pi-app-safe-area-bottom) env(safe-area-inset-left); color: var(--pi-text); background: var(--pi-bg); font: 14px system-ui, sans-serif; }
-  :host([pwa-display-mode]) { --pi-app-safe-area-bottom: env(safe-area-inset-bottom); }
+  /* On Android standalone PWAs (Chromium edge-to-edge) env(safe-area-inset-bottom) often resolves to 0 even though the gesture nav bar overlaps content, clipping the composer (model picker + send). Floor it so bottom controls clear the gesture bar; devices with a real inset (e.g. iOS home indicator) still win. */
+  :host([pwa-display-mode]) { --pi-app-safe-area-bottom: max(env(safe-area-inset-bottom, 0px), 20px); }
   @media (display-mode: standalone), (display-mode: fullscreen), (display-mode: minimal-ui) {
-    :host { --pi-app-safe-area-bottom: env(safe-area-inset-bottom); }
+    :host { --pi-app-safe-area-bottom: max(env(safe-area-inset-bottom, 0px), 20px); }
   }
   .shell { --navigation-panel-size: 340px; --workspace-panel-size: minmax(360px, 42vw); --navigation-panel-width: var(--navigation-panel-size); --workspace-panel-width: var(--workspace-panel-size); display: grid; grid-template-columns: var(--navigation-panel-width) 1px minmax(320px, 1fr) 1px var(--workspace-panel-width); height: 100%; min-height: 0; }
   aside { grid-column: 1; display: flex; flex-direction: column; min-height: 0; overflow: hidden; }


### PR DESCRIPTION
## Problem

On an Android phone, when PI WEB is installed as a standalone PWA (e.g. via Brave "Install app" on a Fairphone 4), the bottom of the chat composer is clipped: the model picker and the send button are only half visible. Nothing in PI WEB config adjusts this.

## Root cause

The app shell reserves `env(safe-area-inset-bottom)` for the bottom safe area in standalone PWA display modes ([`src/client/src/components/shared.ts`](https://github.com/jmfederico/pi-web/blob/main/src/client/src/components/shared.ts)):

```css
:host([pwa-display-mode]) { --pi-app-safe-area-bottom: env(safe-area-inset-bottom); }
@media (display-mode: standalone), (display-mode: fullscreen), (display-mode: minimal-ui) {
  :host { --pi-app-safe-area-bottom: env(safe-area-inset-bottom); }
}
```

On Android standalone PWAs (Chromium edge-to-edge, [Chrome 135+](https://developer.chrome.com/docs/css-ui/edge-to-edge)) `env(safe-area-inset-bottom)` frequently resolves to `0` in the standalone WebView even though the gesture navigation bar overlaps content. The composer is the bottom row of the `.shell` grid inside the padded `:host`, so a `0` bottom inset lets it render behind the gesture bar and get clipped.

This is not isolated to one device: the same `0` inset + clipped bottom controls pattern has been reported for other Android standalone PWAs.

## Fix

Floor the reserved bottom space so the composer always clears the gesture bar, while devices that report a real inset (e.g. the iOS home indicator) still use it:

```css
:host([pwa-display-mode]) { --pi-app-safe-area-bottom: max(env(safe-area-inset-bottom, 0px), 20px); }
@media (display-mode: standalone), (display-mode: fullscreen), (display-mode: minimal-ui) {
  :host { --pi-app-safe-area-bottom: max(env(safe-area-inset-bottom, 0px), 20px); }
}
```

The `20px` floor only applies in standalone display modes (browser-tab mode keeps `--pi-app-safe-area-bottom: 0px`), so desktop and non-PWA mobile are unaffected.

## Testing

Installed PI WEB as a standalone PWA via Brave on a Fairphone 4 (Android). Before the fix, the model picker and send button were half hidden behind the gesture nav bar. After the fix, the full composer is visible and reachable.

- [x] Android standalone PWA (Brave, Fairphone 4): composer fully visible
- [x] Desktop browser: unchanged (no bottom inset reserved outside standalone)
- [ ] iOS standalone: real inset (~34px) should still win — *not tested here; the `max()` keeps the larger real inset*

## Notes

`env(safe-area-inset-bottom, 0px)` is used with an explicit `0px` fallback for older browsers that don't implement the inset, so `max()` still resolves to the `20px` floor rather than failing open with `0`.
