### PR TITLE
feat: add MiniMax provider endpoints

### DIFF
--- a/.changeset/minimax-provider-endpoints.md
+++ b/.changeset/minimax-provider-endpoints.md
@@ -1,0 +1,5 @@
+---
+"@jmfederico/pi-web": patch
+---
+
+Register MiniMax-M3 and MiniMax-M2.7 for the global and China Anthropic-compatible and OpenAI-compatible endpoints.

--- a/extensions/lib/minimax.ts
+++ b/extensions/lib/minimax.ts
@@ -1,0 +1,200 @@
+import type { Api, Context, Model, SimpleStreamOptions } from "@earendil-works/pi-ai";
+import { streamSimple as streamAnthropicMessages } from "@earendil-works/pi-ai/api/anthropic-messages";
+import { streamSimple as streamOpenAICompletions } from "@earendil-works/pi-ai/api/openai-completions";
+import type { ProviderConfig, ProviderModelConfig } from "@earendil-works/pi-coding-agent";
+
+type MiniMaxApi = "anthropic-messages" | "openai-completions";
+type MiniMaxModelId = "MiniMax-M3" | "MiniMax-M2.7";
+
+interface MiniMaxModelFacts extends Omit<ProviderModelConfig, "api" | "baseUrl" | "compat"> {
+  id: MiniMaxModelId;
+}
+
+interface MiniMaxProviderRegistration {
+  id: string;
+  name: string;
+  api: MiniMaxApi;
+  baseUrl: string;
+  apiKey?: string;
+}
+
+interface MiniMaxProviderRegistrar {
+  registerProvider(name: string, config: ProviderConfig): void;
+}
+
+const MINI_MAX_MODELS: readonly MiniMaxModelFacts[] = [
+  {
+    id: "MiniMax-M3",
+    name: "MiniMax-M3",
+    reasoning: true,
+    input: ["text", "image"],
+    cost: {
+      input: 0.6,
+      output: 2.4,
+      cacheRead: 0.12,
+      // Pi represents an unpublished cache-write price as zero.
+      cacheWrite: 0,
+    },
+    contextWindow: 1_000_000,
+    maxTokens: 128_000,
+  },
+  {
+    id: "MiniMax-M2.7",
+    name: "MiniMax-M2.7",
+    reasoning: true,
+    thinkingLevelMap: { off: null },
+    input: ["text"],
+    cost: {
+      input: 0.3,
+      output: 1.2,
+      cacheRead: 0.06,
+      cacheWrite: 0.375,
+    },
+    contextWindow: 204_800,
+    maxTokens: 131_072,
+  },
+];
+
+const MINI_MAX_PROVIDERS: readonly MiniMaxProviderRegistration[] = [
+  {
+    id: "minimax",
+    name: "MiniMax",
+    api: "anthropic-messages",
+    baseUrl: "https://api.minimax.io/anthropic",
+  },
+  {
+    id: "minimax-cn",
+    name: "MiniMax CN",
+    api: "anthropic-messages",
+    baseUrl: "https://api.minimaxi.com/anthropic",
+  },
+  {
+    id: "minimax-openai",
+    name: "MiniMax OpenAI",
+    api: "openai-completions",
+    baseUrl: "https://api.minimax.io/v1",
+    apiKey: "$MINIMAX_API_KEY",
+  },
+  {
+    id: "minimax-openai-cn",
+    name: "MiniMax OpenAI CN",
+    api: "openai-completions",
+    baseUrl: "https://api.minimaxi.com/v1",
+    apiKey: "$MINIMAX_CN_API_KEY",
+  },
+];
+
+const OPENAI_COMPAT: NonNullable<ProviderModelConfig["compat"]> = {
+  supportsStore: false,
+  supportsDeveloperRole: false,
+  supportsReasoningEffort: false,
+  supportsStrictMode: false,
+  maxTokensField: "max_completion_tokens",
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isModelForApi<T extends MiniMaxApi>(model: Model<Api>, api: T): model is Model<T> {
+  return model.api === api;
+}
+
+export function adaptMiniMaxPayload(
+  api: MiniMaxApi,
+  modelId: string,
+  reasoning: SimpleStreamOptions["reasoning"],
+  payload: unknown,
+): unknown {
+  if (!isRecord(payload)) return payload;
+
+  const adapted = { ...payload };
+  delete adapted["reasoning_effort"];
+  delete adapted["output_config"];
+
+  if (api === "openai-completions") adapted["reasoning_split"] = true;
+
+  if (modelId === "MiniMax-M3") {
+    adapted["thinking"] = { type: reasoning === undefined ? "disabled" : "adaptive" };
+  } else if (modelId === "MiniMax-M2.7") {
+    // M2.7 always thinks, so leave control to the endpoint default.
+    delete adapted["thinking"];
+  }
+
+  return adapted;
+}
+
+function withMiniMaxPayloadAdapter(
+  api: MiniMaxApi,
+  model: Model<Api>,
+  options: SimpleStreamOptions | undefined,
+): SimpleStreamOptions {
+  const callerOnPayload = options?.onPayload;
+  return {
+    ...options,
+    async onPayload(payload, payloadModel) {
+      const adapted = adaptMiniMaxPayload(api, model.id, options?.reasoning, payload);
+      if (callerOnPayload === undefined) return adapted;
+      return await callerOnPayload(adapted, payloadModel) ?? adapted;
+    },
+  };
+}
+
+function streamMiniMaxAnthropic(
+  model: Model<Api>,
+  context: Context,
+  options?: SimpleStreamOptions,
+) {
+  if (!isModelForApi(model, "anthropic-messages")) {
+    throw new Error(`MiniMax Anthropic stream received ${model.api} model`);
+  }
+  return streamAnthropicMessages(
+    model,
+    context,
+    withMiniMaxPayloadAdapter("anthropic-messages", model, options),
+  );
+}
+
+function streamMiniMaxOpenAI(
+  model: Model<Api>,
+  context: Context,
+  options?: SimpleStreamOptions,
+) {
+  if (!isModelForApi(model, "openai-completions")) {
+    throw new Error(`MiniMax OpenAI stream received ${model.api} model`);
+  }
+  return streamOpenAICompletions(
+    model,
+    context,
+    withMiniMaxPayloadAdapter("openai-completions", model, options),
+  );
+}
+
+function modelsFor(api: MiniMaxApi, baseUrl: string): ProviderModelConfig[] {
+  return MINI_MAX_MODELS.map((model) => ({
+    ...model,
+    input: [...model.input],
+    cost: { ...model.cost },
+    ...(model.thinkingLevelMap === undefined
+      ? {}
+      : { thinkingLevelMap: { ...model.thinkingLevelMap } }),
+    api,
+    baseUrl,
+    ...(api === "openai-completions" ? { compat: { ...OPENAI_COMPAT } } : {}),
+  }));
+}
+
+export function registerMiniMaxProviders(pi: MiniMaxProviderRegistrar): void {
+  for (const provider of MINI_MAX_PROVIDERS) {
+    pi.registerProvider(provider.id, {
+      name: provider.name,
+      baseUrl: provider.baseUrl,
+      api: provider.api,
+      ...(provider.apiKey === undefined ? {} : { apiKey: provider.apiKey }),
+      models: modelsFor(provider.api, provider.baseUrl),
+      streamSimple: provider.api === "anthropic-messages"
+        ? streamMiniMaxAnthropic
+        : streamMiniMaxOpenAI,
+    });
+  }
+}

--- a/extensions/pi-web.ts
+++ b/extensions/pi-web.ts
@@ -4,6 +4,7 @@ import { homedir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
+import { registerMiniMaxProviders } from "./lib/minimax.js";
 
 const packageRoot = dirname(dirname(fileURLToPath(import.meta.url)));
 const cliPath = join(packageRoot, "dist", "cli.js");
@@ -88,6 +89,8 @@ async function boundedLogs(): Promise<{ code: number; output: string }> {
 }
 
 export default function piWebExtension(pi: ExtensionAPI): void {
+  registerMiniMaxProviders(pi);
+
   pi.registerCommand("pi-web", {
     description: "Manage PI WEB services: install, status, logs, restart, start, stop, doctor, version, open",
     getArgumentCompletions(prefix: string): { value: string; label: string }[] | null {

--- a/src/minimaxExtension.test.ts
+++ b/src/minimaxExtension.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+import type { ProviderConfig, ProviderModelConfig } from "@earendil-works/pi-coding-agent";
+import { adaptMiniMaxPayload, registerMiniMaxProviders } from "../extensions/lib/minimax.js";
+
+interface Registration {
+  id: string;
+  config: ProviderConfig;
+}
+
+function registeredProviders(): Registration[] {
+  const registrations: Registration[] = [];
+  registerMiniMaxProviders({
+    registerProvider(id, config) {
+      registrations.push({ id, config });
+    },
+  });
+  return registrations;
+}
+
+function models(config: ProviderConfig): ProviderModelConfig[] {
+  expect(config.models).toBeDefined();
+  return config.models ?? [];
+}
+
+describe("registerMiniMaxProviders", () => {
+  it("registers global and China endpoints for both supported API protocols", () => {
+    const registrations = registeredProviders();
+
+    expect(registrations.map(({ id, config }) => ({
+      id,
+      name: config.name,
+      api: config.api,
+      baseUrl: config.baseUrl,
+      apiKey: config.apiKey,
+    }))).toEqual([
+      {
+        id: "minimax",
+        name: "MiniMax",
+        api: "anthropic-messages",
+        baseUrl: "https://api.minimax.io/anthropic",
+        apiKey: undefined,
+      },
+      {
+        id: "minimax-cn",
+        name: "MiniMax CN",
+        api: "anthropic-messages",
+        baseUrl: "https://api.minimaxi.com/anthropic",
+        apiKey: undefined,
+      },
+      {
+        id: "minimax-openai",
+        name: "MiniMax OpenAI",
+        api: "openai-completions",
+        baseUrl: "https://api.minimax.io/v1",
+        apiKey: "$MINIMAX_API_KEY",
+      },
+      {
+        id: "minimax-openai-cn",
+        name: "MiniMax OpenAI CN",
+        api: "openai-completions",
+        baseUrl: "https://api.minimaxi.com/v1",
+        apiKey: "$MINIMAX_CN_API_KEY",
+      },
+    ]);
+  });
+
+  it("registers the current MiniMax-M3 and MiniMax-M2.7 model facts", () => {
+    for (const { config } of registeredProviders()) {
+      expect(models(config)).toEqual([
+        expect.objectContaining({
+          id: "MiniMax-M3",
+          name: "MiniMax-M3",
+          api: config.api,
+          baseUrl: config.baseUrl,
+          reasoning: true,
+          input: ["text", "image"],
+          cost: { input: 0.6, output: 2.4, cacheRead: 0.12, cacheWrite: 0 },
+          contextWindow: 1_000_000,
+          maxTokens: 128_000,
+        }),
+        expect.objectContaining({
+          id: "MiniMax-M2.7",
+          name: "MiniMax-M2.7",
+          api: config.api,
+          baseUrl: config.baseUrl,
+          reasoning: true,
+          thinkingLevelMap: { off: null },
+          input: ["text"],
+          cost: { input: 0.3, output: 1.2, cacheRead: 0.06, cacheWrite: 0.375 },
+          contextWindow: 204_800,
+          maxTokens: 131_072,
+        }),
+      ]);
+    }
+  });
+});
+
+describe("adaptMiniMaxPayload", () => {
+  it("maps MiniMax-M3 thinking controls for both protocols", () => {
+    expect(adaptMiniMaxPayload(
+      "openai-completions",
+      "MiniMax-M3",
+      "high",
+      { reasoning_effort: "high", output_config: { effort: "high" } },
+    )).toEqual({ reasoning_split: true, thinking: { type: "adaptive" } });
+
+    expect(adaptMiniMaxPayload(
+      "anthropic-messages",
+      "MiniMax-M3",
+      undefined,
+      { thinking: { type: "enabled", budget_tokens: 1024 } },
+    )).toEqual({ thinking: { type: "disabled" } });
+  });
+
+  it("leaves MiniMax-M2.7 thinking always on at the endpoint", () => {
+    expect(adaptMiniMaxPayload(
+      "openai-completions",
+      "MiniMax-M2.7",
+      undefined,
+      { reasoning_effort: "high", thinking: { type: "disabled" } },
+    )).toEqual({ reasoning_split: true });
+  });
+});


### PR DESCRIPTION
Reason: Add MiniMax-M3 and MiniMax-M2.7 to the global Pi provider baseline for both regional API-compatible endpoint families.

This change:

- Registers the global and China Anthropic-compatible endpoints.
- Registers the global and China OpenAI-compatible endpoints.
- Adds the target model context, pricing, input, and thinking metadata.
- Adapts protocol payloads for MiniMax thinking controls and reasoning output.
- Adds focused registration and payload tests plus a patch changeset.

Checks:

- `npm test -- --run src/minimaxExtension.test.ts`
- `npm run typecheck`
- `npx eslint extensions/lib/minimax.ts extensions/pi-web.ts src/minimaxExtension.test.ts`
- `npm run build`
- `npm run pack:dry`
- `npm run verify:staged`
- Required secret scan
