### PR TITLE
chore(deps): upgrade pi packages to 0.83.0

### DIFF
--- a/.changeset/upgrade-pi-0-83.md
+++ b/.changeset/upgrade-pi-0-83.md
@@ -1,0 +1,5 @@
+---
+"@jmfederico/pi-web": patch
+---
+
+Upgrade the bundled Pi coding agent to 0.83.0, bringing credential export commands, headless OpenRouter sign-in, Claude Opus 5 on GitHub Copilot, and upstream session and provider fixes.

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "lit": "^3.3.3",
         "marked": "^18.0.6",
         "node-pty": "^1.1.0",
-        "typebox": "1.3.6",
+        "typebox": "1.3.7",
         "undici": "^8.5.0",
         "ws": "^8.21.0"
       },
@@ -43,9 +43,9 @@
       },
       "devDependencies": {
         "@changesets/cli": "^2.31.0",
-        "@earendil-works/pi-agent-core": "^0.82.1",
-        "@earendil-works/pi-ai": "^0.82.1",
-        "@earendil-works/pi-coding-agent": "^0.82.1",
+        "@earendil-works/pi-agent-core": "^0.83.0",
+        "@earendil-works/pi-ai": "^0.83.0",
+        "@earendil-works/pi-coding-agent": "^0.83.0",
         "@eslint/js": "^10.0.1",
         "@types/node": "^24.13.3",
         "@types/ws": "^8.18.1",
@@ -63,9 +63,9 @@
         "node": ">=22.19.0"
       },
       "peerDependencies": {
-        "@earendil-works/pi-agent-core": ">=0.82.1 <0.83",
-        "@earendil-works/pi-ai": ">=0.82.1 <0.83",
-        "@earendil-works/pi-coding-agent": ">=0.82.1 <0.83"
+        "@earendil-works/pi-agent-core": ">=0.83.0 <0.84",
+        "@earendil-works/pi-ai": ">=0.83.0 <0.84",
+        "@earendil-works/pi-coding-agent": ">=0.83.0 <0.84"
       }
     },
     "node_modules/@anthropic-ai/sdk": {
@@ -169,17 +169,17 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.977.1",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.1.tgz",
-      "integrity": "sha512-KVtQRtc00ES/y+Sc3vYXeP6pCIcNlBJCZOwvqSy8ZpVGmbM5+IG+AfhuTKQ2oXmIVqZJewaGMMpzPkywC6xg0w==",
+      "version": "3.977.6",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.6.tgz",
+      "integrity": "sha512-QiaJV4/zDrB4ZY2mfeSXSzSTc36W16sZXcGz+SPFk0CJ26gziO0cS+4LjJUMAbdeeBOvS0k0Aq1cZpfGdUXxSw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.974.2",
         "@aws-sdk/xml-builder": "^3.972.37",
         "@aws/lambda-invoke-store": "^0.3.0",
-        "@smithy/core": "^3.29.8",
-        "@smithy/signature-v4": "^5.6.9",
+        "@smithy/core": "^3.31.1",
+        "@smithy/signature-v4": "^5.6.12",
         "@smithy/types": "^4.16.1",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
@@ -189,15 +189,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.61",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.61.tgz",
-      "integrity": "sha512-qihs2ekMb89Nxd2JenCgVFhjbkb3EIo7HEBCBzyZACKVJdrLUZBLOmAE3xr0Sayml8n/jZSzwO/IufIiIzO7PQ==",
+      "version": "3.972.67",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.67.tgz",
+      "integrity": "sha512-rcIpk5kxUqDaaNa6Xk23pQ6ViY7jlqzmfFWCahQcBT97ddXaXYYwzCen9Tz1Jvo6aJft6wDl5bN44/Jw5B4oLA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.0",
+        "@aws-sdk/core": "^3.977.6",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.8",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -206,17 +206,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.63",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.63.tgz",
-      "integrity": "sha512-yfozsS8wkWZEi/n6IsrodcFKBWZ0iNAezhJbTReMNc0z1Px17qdeAeuL1/wziCAmCZyXiW7QzP75ggJkBQv8jQ==",
+      "version": "3.972.69",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.69.tgz",
+      "integrity": "sha512-nggwJtZ4eeNsUw5IeWBMXsi1ryct5idi0K+/SCRF3kybLubOMaNTb3XCihXpWMiVpyzyPeIrl0zTkzhBH9porA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.0",
+        "@aws-sdk/core": "^3.977.6",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.8",
-        "@smithy/fetch-http-handler": "^5.6.10",
-        "@smithy/node-http-handler": "^4.9.10",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -225,13 +225,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http/node_modules/@smithy/node-http-handler": {
-      "version": "4.9.11",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.11.tgz",
-      "integrity": "sha512-slbzbz8taEOzoXv/9y34YNBoE+ZHmddLykCgjDAjvMAsu2nM5s2Gzwa5OGF721tD8s+CKeFUBds5lSj9lcbuDg==",
+      "version": "4.9.13",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.13.tgz",
+      "integrity": "sha512-Nmd/Nl35zfYrd+a6OO2cDJb3GPh9bgTjIUhcM+JFfjpp8/osCgboDV5nCT1I01Pv6R13eSKDKLSoVa5ZB6Zsfw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.30.0",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -240,23 +240,23 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.973.6",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.6.tgz",
-      "integrity": "sha512-jGLTW1bj148GL/6/IMlfY2fMYS9FtHOG+NahkFD4y0qkzYudNUahelxryY68/HGMslYuHClk1XaS/3b3eJzEkg==",
+      "version": "3.973.12",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.12.tgz",
+      "integrity": "sha512-pNEf/OeyN5X3VmLKlgSO6TqaWmW10CvI3TfwL1XhsuhYjSLT2VDaxFnCPHnOeQXSaFisMX4jNhpETriqN8DOmg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.0",
-        "@aws-sdk/credential-provider-env": "^3.972.61",
-        "@aws-sdk/credential-provider-http": "^3.972.63",
-        "@aws-sdk/credential-provider-login": "^3.972.68",
-        "@aws-sdk/credential-provider-process": "^3.972.61",
-        "@aws-sdk/credential-provider-sso": "^3.973.5",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.67",
-        "@aws-sdk/nested-clients": "^3.997.35",
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/credential-provider-env": "^3.972.67",
+        "@aws-sdk/credential-provider-http": "^3.972.69",
+        "@aws-sdk/credential-provider-login": "^3.972.74",
+        "@aws-sdk/credential-provider-process": "^3.972.67",
+        "@aws-sdk/credential-provider-sso": "^3.973.11",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.73",
+        "@aws-sdk/nested-clients": "^3.997.41",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.8",
-        "@smithy/credential-provider-imds": "^4.4.13",
+        "@smithy/core": "^3.31.1",
+        "@smithy/credential-provider-imds": "^4.4.16",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -265,16 +265,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.68",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.68.tgz",
-      "integrity": "sha512-w6tNci6g7RqFpLhj1f5xseBvaNojb4Pkgp5Jp5apl9hrJtaf2AA+rX9+qlhlWUK6kcyAFYPA7emO+55zj+S98Q==",
+      "version": "3.972.74",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.74.tgz",
+      "integrity": "sha512-0AQfDcf99TNmqVKv0owHrw/TQs6i4ZE5t9qmz6NvO53bE/sA/tpXhXL9AAcEP1qHc6Zzjd1UMb69+/9zdhvY3g==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.0",
-        "@aws-sdk/nested-clients": "^3.997.35",
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/nested-clients": "^3.997.41",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.8",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -283,21 +283,21 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.72",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.72.tgz",
-      "integrity": "sha512-blQ7F5QGzylnzeh5549zQLoCAiMHkXFLjFovEMaVy4b2X8JhUu+u9NXro1hyK95YHdVFNmBHKs2hIHtZchxKlQ==",
+      "version": "3.972.78",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.78.tgz",
+      "integrity": "sha512-OgPAnfvbGAMWac6yvxJ1ihslrvDpPVwR68D2csospdNCCyPvHk9JLzYKwz48SNiS1T2znDwHauywRKRFfpyYng==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.61",
-        "@aws-sdk/credential-provider-http": "^3.972.63",
-        "@aws-sdk/credential-provider-ini": "^3.973.6",
-        "@aws-sdk/credential-provider-process": "^3.972.61",
-        "@aws-sdk/credential-provider-sso": "^3.973.5",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.67",
+        "@aws-sdk/credential-provider-env": "^3.972.67",
+        "@aws-sdk/credential-provider-http": "^3.972.69",
+        "@aws-sdk/credential-provider-ini": "^3.973.12",
+        "@aws-sdk/credential-provider-process": "^3.972.67",
+        "@aws-sdk/credential-provider-sso": "^3.973.11",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.73",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.8",
-        "@smithy/credential-provider-imds": "^4.4.13",
+        "@smithy/core": "^3.31.1",
+        "@smithy/credential-provider-imds": "^4.4.16",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -306,15 +306,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.61",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.61.tgz",
-      "integrity": "sha512-xzRuj+fUVO4nkafKQJVKAF97kGpeQbfjuwmRrtGZNf42/1dkmcz6o7dswBy7alY0htQn5sCL1GWQYEykviWZkA==",
+      "version": "3.972.67",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.67.tgz",
+      "integrity": "sha512-IlUEejorGTWKb4/Dm7K5Yw4QxUmXLThLhrvBmzVBqZFTbW72cv9LTcITmo1dsnYriALE4h68mOq4LB99x6sQ7Q==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.0",
+        "@aws-sdk/core": "^3.977.6",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.8",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -323,17 +323,17 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.973.5",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.5.tgz",
-      "integrity": "sha512-fZRjjWhLFelsDoOYjqShQTrIGYC3Pf9Mx9Czf+1ikfQDgktxjze33dVo1q1/ZQ+T0qbtejVoHNHrfD5aJVpv/w==",
+      "version": "3.973.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.11.tgz",
+      "integrity": "sha512-gAQBkBZxUB84d71+pPcI9L+jh2ujhuAVxc/4FgGiWFDjkPBlMKxzd5XDtkSXTFX8Ro7ansnT88+XadasxMeCRw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.0",
-        "@aws-sdk/nested-clients": "^3.997.35",
-        "@aws-sdk/token-providers": "3.1095.0",
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/nested-clients": "^3.997.41",
+        "@aws-sdk/token-providers": "3.1103.0",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.8",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -342,16 +342,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso/node_modules/@aws-sdk/token-providers": {
-      "version": "3.1095.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1095.0.tgz",
-      "integrity": "sha512-65SudS6y4nzaYHybtqcpm3sHe5jLhdMn68HRKS1nUx690BtQeaAQOoujQ+dpOjBATIVGVgKKjEP8tR+U06QJQA==",
+      "version": "3.1103.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1103.0.tgz",
+      "integrity": "sha512-N4wy26MNn31ItGVHYHPrEuCIFY4MBBjC+C5v1lJKqIUSA7OZBdhleCY53zCCrXn27hsk7YNOaTuhQu807S4AfQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.0",
-        "@aws-sdk/nested-clients": "^3.997.35",
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/nested-clients": "^3.997.41",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.8",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -360,16 +360,16 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.67",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.67.tgz",
-      "integrity": "sha512-FTNZ05gkPBA6CKbU3N4zPgybV+stdazwMOya75CmGdcJL7p8Fw/BdHP8WVxJd0mvzyPK2cg/C3gli58Ir4HgCw==",
+      "version": "3.972.73",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.73.tgz",
+      "integrity": "sha512-SnlEmQa6SjOgs6iOPLUQl1Eyq4AKiAdPQlkOhFhqNfDtDCwibMGvL6QlkSmf3o6vAUSImzdPCxowT5dfQUZP1A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.0",
-        "@aws-sdk/nested-clients": "^3.997.35",
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/nested-clients": "^3.997.41",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.8",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -378,14 +378,14 @@
       }
     },
     "node_modules/@aws-sdk/eventstream-handler-node": {
-      "version": "3.972.30",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.30.tgz",
-      "integrity": "sha512-hJboPgIpq5+ADc++/B9TBqn65CXV21cZLGB8V5RBQbxkZ/rQ6qMfcxTnW/SvQlasX4jhaSG8B1wsVjhQyDrsnQ==",
+      "version": "3.972.31",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-handler-node/-/eventstream-handler-node-3.972.31.tgz",
+      "integrity": "sha512-/BRzvkp46mF6eXBL/l9WKPQQfifLlUPaWli6n9/T/WDLUg8he7TCyuNFnk6RvHP5j5W/kMj5Gxw7W778LJaXDA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.8",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -394,14 +394,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-eventstream": {
-      "version": "3.972.25",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.25.tgz",
-      "integrity": "sha512-9SFbPzJDHHR5k6Q6KvXVas/veUm/TzNcNTFM2UhdXHZHpyIvI2lS+s4cxljw1BihGpVhsAkQDo/2nW7dHxpf4Q==",
+      "version": "3.972.26",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-eventstream/-/middleware-eventstream-3.972.26.tgz",
+      "integrity": "sha512-2eIvouTZoxPu5ClHY6ij13De1yhY8Rmllt0dlGeBNXX3wmR7fU1pvMCGb50fKm1GxcuntWK0t1T0cMjTyDoUQA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.8",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -410,17 +410,17 @@
       }
     },
     "node_modules/@aws-sdk/middleware-websocket": {
-      "version": "3.972.43",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.43.tgz",
-      "integrity": "sha512-n29++15Vma64Kd0enp9Bo8a6LTm8TvUoMbJEwqXtIksv0oEs+SUCRMm3gozDfPD1Ly0k/sSBughxarlLlRF6Xw==",
+      "version": "3.972.49",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-websocket/-/middleware-websocket-3.972.49.tgz",
+      "integrity": "sha512-wGYJvu1/stdWuzGcNyh44u8aY7ArU8XFrMesBlzIYn70HWVCRBNEngQexDuPIMu0NEgsKGKmTc0uvnS/bF7KWw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.0",
+        "@aws-sdk/core": "^3.977.6",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.8",
-        "@smithy/fetch-http-handler": "^5.6.10",
-        "@smithy/signature-v4": "^5.6.9",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/signature-v4": "^5.6.12",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -429,18 +429,18 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.35",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.35.tgz",
-      "integrity": "sha512-2MJfseVG/aXvIyOIBlYA/Oaf6qFDdsu4D8RKsEUdOQpVuLaor0BdxIBBtJLBNQQEe6Ku3YMvLljwb1MwVUpzRw==",
+      "version": "3.997.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.41.tgz",
+      "integrity": "sha512-RDHqPGQWlF6tatA/Tp3rg6oIwtgN9IVderxE+9av2Y93Dfyu+mO1hZ5Bu2jpfZg2rwdNbsssnwM+sLafIczMlQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.0",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.42",
+        "@aws-sdk/core": "^3.977.6",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.43",
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/core": "^3.29.8",
-        "@smithy/fetch-http-handler": "^5.6.10",
-        "@smithy/node-http-handler": "^4.9.10",
+        "@smithy/core": "^3.31.1",
+        "@smithy/fetch-http-handler": "^5.6.13",
+        "@smithy/node-http-handler": "^4.9.13",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -449,13 +449,13 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/node-http-handler": {
-      "version": "4.9.11",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.11.tgz",
-      "integrity": "sha512-slbzbz8taEOzoXv/9y34YNBoE+ZHmddLykCgjDAjvMAsu2nM5s2Gzwa5OGF721tD8s+CKeFUBds5lSj9lcbuDg==",
+      "version": "4.9.13",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.9.13.tgz",
+      "integrity": "sha512-Nmd/Nl35zfYrd+a6OO2cDJb3GPh9bgTjIUhcM+JFfjpp8/osCgboDV5nCT1I01Pv6R13eSKDKLSoVa5ZB6Zsfw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.30.0",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -464,14 +464,14 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.42",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.42.tgz",
-      "integrity": "sha512-DBV4naZP6HYBlAvPpoQzOP12Wvfou/5rN8yJPXjBTBylU5qwCbh/tXr2MddHoIjgoRkEl/eS+IljiUqvmwey1Q==",
+      "version": "3.996.43",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.43.tgz",
+      "integrity": "sha512-lKekx8bLBXSv4O+cslk9Zfnw2XKSkWBs3uWL5QGhH2ZAQfNS7FE0vcSSN2vD/AhxX54ZTywWxR4STThoeOXlBA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.974.2",
-        "@smithy/signature-v4": "^5.6.9",
+        "@smithy/signature-v4": "^5.6.12",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -986,16 +986,16 @@
       }
     },
     "node_modules/@earendil-works/pi-agent-core": {
-      "version": "0.82.1",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.82.1.tgz",
-      "integrity": "sha512-Z3kloziJIE2dmrisRckZX8zDca/gIv9/YdFAzeoqpHiLV2wsni6bL4hInNSjVKLbqT+4kqLIkph2JQLKvSepjg==",
+      "version": "0.83.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.83.0.tgz",
+      "integrity": "sha512-RorGp9OH5l3ElpuC5a5ZQ2eWcchZGXflXRzVGkV99y3y6tT+LLNyxoYIdVKvTKWEObwhExeQbTH0fI2tE4iX4g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-ai": "^0.82.1",
+        "@earendil-works/pi-ai": "^0.83.0",
         "diff": "8.0.4",
         "ignore": "7.0.5",
-        "typebox": "1.1.38",
+        "typebox": "1.3.7",
         "yaml": "2.9.0"
       },
       "engines": {
@@ -1012,17 +1012,10 @@
         "node": ">=0.3.1"
       }
     },
-    "node_modules/@earendil-works/pi-agent-core/node_modules/typebox": {
-      "version": "1.1.38",
-      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.38.tgz",
-      "integrity": "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@earendil-works/pi-ai": {
-      "version": "0.82.1",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.82.1.tgz",
-      "integrity": "sha512-3WFYRhEp3lQB3444EhPMBcM7zSaEUE3eJgHOR7s4081NLqbw/FsWilIKWXSua0Gv3sRr7m9xMidR3pPDE7jI/A==",
+      "version": "0.83.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.83.0.tgz",
+      "integrity": "sha512-m3IZD4g3er0V8TC9+Vpgw/sjTKqcJlkcIBy/JvsgRubuuik3tAVzyugUg4rVrShIkkOT69mEd34NEqKUIsl6JQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1036,7 +1029,7 @@
         "https-proxy-agent": "7.0.6",
         "openai": "6.26.0",
         "partial-json": "0.1.7",
-        "typebox": "1.1.38"
+        "typebox": "1.3.7"
       },
       "bin": {
         "pi-ai": "dist/cli.js"
@@ -1045,24 +1038,17 @@
         "node": ">=22.19.0"
       }
     },
-    "node_modules/@earendil-works/pi-ai/node_modules/typebox": {
-      "version": "1.1.38",
-      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.38.tgz",
-      "integrity": "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@earendil-works/pi-coding-agent": {
-      "version": "0.82.1",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.82.1.tgz",
-      "integrity": "sha512-zbkAhoIuDPMF3pKuja0ajZabrMWU29FUMV9A/XMXT/XC1yXs5xt6t6t13GogQFsDrDqbFP4DkZQO1w8rWRAzYA==",
+      "version": "0.83.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.83.0.tgz",
+      "integrity": "sha512-uYhF+FsZxogoSX/AxBcUdiY+ZklubwaXyAoEGA2eQwsHcyEAhUYIKh/WLXe/a8+k8eTCmxb+ZN2Zo9mzQtzbWw==",
       "dev": true,
       "hasShrinkwrap": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-agent-core": "^0.82.1",
-        "@earendil-works/pi-ai": "^0.82.1",
-        "@earendil-works/pi-tui": "^0.82.1",
+        "@earendil-works/pi-agent-core": "^0.83.0",
+        "@earendil-works/pi-ai": "^0.83.0",
+        "@earendil-works/pi-tui": "^0.83.0",
         "@silvia-odwyer/photon-node": "0.3.4",
         "chalk": "5.6.2",
         "cross-spawn": "7.0.6",
@@ -1075,7 +1061,7 @@
         "minimatch": "10.2.5",
         "proper-lockfile": "4.1.2",
         "semver": "7.8.0",
-        "typebox": "1.1.38",
+        "typebox": "1.3.7",
         "undici": "8.5.0",
         "yaml": "2.9.0"
       },
@@ -1552,15 +1538,15 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
-      "version": "0.82.1",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.82.1.tgz",
+      "version": "0.83.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.83.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@earendil-works/pi-ai": "^0.82.1",
+        "@earendil-works/pi-ai": "^0.83.0",
         "diff": "8.0.4",
         "ignore": "7.0.5",
-        "typebox": "1.1.38",
+        "typebox": "1.3.7",
         "yaml": "2.9.0"
       },
       "engines": {
@@ -1568,8 +1554,8 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
-      "version": "0.82.1",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.82.1.tgz",
+      "version": "0.83.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.83.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1583,7 +1569,7 @@
         "https-proxy-agent": "7.0.6",
         "openai": "6.26.0",
         "partial-json": "0.1.7",
-        "typebox": "1.1.38"
+        "typebox": "1.3.7"
       },
       "bin": {
         "pi-ai": "dist/cli.js"
@@ -1593,8 +1579,8 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
-      "version": "0.82.1",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.82.1.tgz",
+      "version": "0.83.0",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.83.0.tgz",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2888,9 +2874,9 @@
       "license": "0BSD"
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/typebox": {
-      "version": "1.1.38",
-      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.1.38.tgz",
-      "integrity": "sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==",
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.3.7.tgz",
+      "integrity": "sha512-meKuifc33Pccx0O6PdIzYMq3Og8zvP4TIi/a+Bw3AEMZMxOD0+RHGQvpglEe6Zdy3wZ8nqn/j95h8LUZLk/6Hg==",
       "dev": true,
       "license": "MIT"
     },
@@ -5344,9 +5330,9 @@
       "license": "MIT"
     },
     "node_modules/@smithy/core": {
-      "version": "3.30.0",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.30.0.tgz",
-      "integrity": "sha512-dl2yRglDxfzH9uJ4fSo4zTaAHa0zH7+V7BZMRWy8hEYIKT1BiqMUK/CN6T3ADQ3kbA5N1tmUulroJ2UtONS7Kw==",
+      "version": "3.31.1",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.31.1.tgz",
+      "integrity": "sha512-CyogUINxvi7C7LDsh8Syo6hVJOT9ckz4rG8dRZfTJ8r91HkMY59PnNooaj7WcHyxEkxPfBAmbgztZU+xTo76lg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -5358,13 +5344,13 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.4.14",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.14.tgz",
-      "integrity": "sha512-QgbuahIb2qxQeZQvNK0sw3aF3JH5zwH8j2lLp5DUasVXexGGMWULAR+7z0omPXFolCP/m5wN9M5lm9EGdSviTQ==",
+      "version": "4.4.16",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.4.16.tgz",
+      "integrity": "sha512-QfuLWAkLzptffFW980AFeHZFdqds2B64rpEd3uJ6lgs3xVn9QegGMUgUcj+4d7dRrAsya3r58ZKpku97WcFb4w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.30.0",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -5373,13 +5359,13 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.6.11",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.11.tgz",
-      "integrity": "sha512-o0Zkj1nKqJAoq+a+BrkhU39tRftMNjLwpc/z06Frfl43wpbHrJMaSAVZE4vTqlxtVkNaGaT0bIDxOp7tkFTuQQ==",
+      "version": "5.6.13",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.6.13.tgz",
+      "integrity": "sha512-4fW86pEUOMbrD5nkbyl/tTvPHHWJFbuB2odl6ps9lWfHoXf9HWh3Q/Smh59qH1g7+c/BSZghX6bbUk4gsiMs8A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.30.0",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -5416,13 +5402,13 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.6.10",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.10.tgz",
-      "integrity": "sha512-EXhWePm3SXJAX38npIy4TXL2Aex/OVgCClTjelN2QHw/U+8CQUH8C7AaxsVzQcYieYPseywn48s89DmvuGjiAg==",
+      "version": "5.6.12",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.6.12.tgz",
+      "integrity": "sha512-I6KLtq3H0qqSuV9vLglfi8puHqzygzWHOnI4z/Rdoo+q50vvo18vBRdPAvvEtcaKROz7Zn6qnPa14kRfPH6PcQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.30.0",
+        "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
       },
@@ -9669,9 +9655,9 @@
       }
     },
     "node_modules/typebox": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.3.6.tgz",
-      "integrity": "sha512-Sc8RA0NCMEFmApHNU9ZMzqcpQj46She44J8ffpLM/bdhLNUZKq7DJumcLcsFx1gRmDfQPgCgOmFFJ7rcnfWNyA==",
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/typebox/-/typebox-1.3.7.tgz",
+      "integrity": "sha512-meKuifc33Pccx0O6PdIzYMq3Og8zvP4TIi/a+Bw3AEMZMxOD0+RHGQvpglEe6Zdy3wZ8nqn/j95h8LUZLk/6Hg==",
       "license": "MIT"
     },
     "node_modules/typescript": {

--- a/package.json
+++ b/package.json
@@ -78,15 +78,15 @@
     "lit": "^3.3.3",
     "marked": "^18.0.6",
     "node-pty": "^1.1.0",
-    "typebox": "1.3.6",
+    "typebox": "1.3.7",
     "undici": "^8.5.0",
     "ws": "^8.21.0"
   },
   "devDependencies": {
     "@changesets/cli": "^2.31.0",
-    "@earendil-works/pi-agent-core": "^0.82.1",
-    "@earendil-works/pi-ai": "^0.82.1",
-    "@earendil-works/pi-coding-agent": "^0.82.1",
+    "@earendil-works/pi-agent-core": "^0.83.0",
+    "@earendil-works/pi-ai": "^0.83.0",
+    "@earendil-works/pi-coding-agent": "^0.83.0",
     "@eslint/js": "^10.0.1",
     "@types/node": "^24.13.3",
     "@types/ws": "^8.18.1",
@@ -116,9 +116,9 @@
   "homepage": "https://pi-web.dev/",
   "packageManager": "npm@11.11.0",
   "peerDependencies": {
-    "@earendil-works/pi-agent-core": ">=0.82.1 <0.83",
-    "@earendil-works/pi-ai": ">=0.82.1 <0.83",
-    "@earendil-works/pi-coding-agent": ">=0.82.1 <0.83"
+    "@earendil-works/pi-agent-core": ">=0.83.0 <0.84",
+    "@earendil-works/pi-ai": ">=0.83.0 <0.84",
+    "@earendil-works/pi-coding-agent": ">=0.83.0 <0.84"
   },
   "keywords": [
     "pi-package",


### PR DESCRIPTION
This commit was left unpushed on the local `perf/fast-session-listing` branch when PR #131 merged, so main got the fast session listing without the pi 0.83.0 upgrade it was built and tested against.

- Bumps `@earendil-works/pi-coding-agent` to ^0.83.0 (peer range >=0.83.0 <0.84)
- Includes the changeset for the release notes