### PR TITLE
fix(relay): keep finish line stable across legs

### DIFF
--- a/.pi/prompts/relay-worktree.md
+++ b/.pi/prompts/relay-worktree.md
@@ -3,7 +3,7 @@ description: Plan a PI WEB Relay in a fresh worktree and dispatch its setup leg
 argument-hint: "<what the relay should achieve>"
 ---
 
-Read and follow `.pi/prompts/relay.md` in full for the task below, forcing **worktree mode** instead of its in-place default. Apply its empty-task and source-material handling to this task description.
+This wrapper only selects worktree mode. Read and follow `.pi/prompts/relay.md` in full for the task below, forcing **worktree mode** instead of its in-place default. Apply its empty-task and source-material handling to this task description.
 
 ## Task description
 

--- a/.pi/prompts/relay.md
+++ b/.pi/prompts/relay.md
@@ -7,7 +7,7 @@ Plan and dispatch a Relay for the task described at the end of this prompt.
 
 If the task description is empty, ask what the relay should achieve before doing anything else.
 
-Load the `relay` skill first. It owns the Relay method, packet, context discipline, and handoff protocol. This prompt adds only PI WEB's repository-specific operating policy.
+Load the `relay` skill first. It owns the Relay method, packet roles and defaults, document authority, context discipline, and handoff protocol. This prompt adds PI WEB's repository-specific operating instructions.
 
 ## Canonical repository instructions
 
@@ -19,7 +19,7 @@ Use `.agents/skills/code-quality-architecture/SKILL.md` as the implementation an
 
 Use **in-place mode** — the current checkout and branch — unless this prompt was invoked through `/relay-worktree` or the task explicitly asks for a worktree. If the intended mode is ambiguous, prefer asking the user over guessing.
 
-Use the packet location defined by the `relay` skill. In worktree mode, create the packet inside the new worktree, not the dispatching checkout.
+In worktree mode, create the packet inside the new worktree, not the dispatching checkout.
 
 Establish and record the base ref and base commit used for whole-work review. Unless the task names another base, use `origin/main`.
 
@@ -27,19 +27,19 @@ Establish and record the base ref and base commit used for whole-work review. Un
 
 The phase immediately before the pull-request phase is a whole-work review:
 
-- Begin it only after implementation and verification are believed complete, and review the complete diff from the recorded base.
+- Begin it only after implementation and verification are believed complete, and review the complete diff from the recorded base against the charter's finish line, any stable supporting material it designates, and the applicable canonical quality instructions.
 - The reviewer reports findings and does not modify production code.
-- If blocking findings exist, record them in risk order, name one coherent remediation leg in `status.md`, and dispatch it.
+- If blocking findings exist, record them in risk order in `log.md`, name one coherent remediation leg in `status.md` with a pointer to that record, and dispatch it.
 - A remediation runner fixes and commits only that task, then dispatches a fresh whole-work reviewer.
-- Repeat until a reviewer records an explicit approval and the exact reviewed HEAD, then names the pull-request leg.
+- Repeat until a reviewer records an explicit approval and the exact reviewed HEAD in `log.md`; `status.md` then points to that approval record and names the pull-request leg.
 
-The whole-work reviewer decides how much independent review is proportionate and records that decision in `log.md`. It may review directly or use `spawn_subsession` for focused or independent report-only reviews, then `yield_to_subsessions` and consolidate their findings. Subreview prompts must identify the repository, base, exact diff scope, canonical quality instructions, and the prohibition on code changes. Do not assume particular model IDs are available. The Relay handoff remains one `spawn_session` at the end of the leg.
+The whole-work reviewer decides how much independent review is proportionate and records that decision in `log.md`. It may review directly or use `spawn_subsession` for focused or independent report-only reviews, then `yield_to_subsessions` and consolidate their findings. Subreview prompts must identify the repository, base, exact diff scope, charter finish line and designated supporting material, canonical quality instructions, and the prohibition on code changes. Do not assume particular model IDs are available. The Relay handoff remains one `spawn_session` at the end of the leg.
 
 ## Pull-request finish
 
 The final leg creates or updates the pull request:
 
-- First verify that HEAD equals the approved HEAD and that the working tree is clean, apart from the ignored Relay packet. If either check fails, dispatch a fresh whole-work review instead.
+- First read the targeted approval entry cited by `status.md`, then verify that HEAD equals the reviewed HEAD recorded there and that the working tree is clean, apart from the ignored Relay packet. If either check fails, dispatch a fresh whole-work review instead.
 - Push the branch and create a pull request, or update the existing pull request for that branch.
 - State what changed and why, behavioral or contract changes, migration or deployment ordering when applicable, and the exact verification performed with results.
 - Finish only after the pull-request URL is recorded in `status.md` and `log.md`. Push or authentication failure is an intervention, not completion.
@@ -57,11 +57,11 @@ In in-place mode, leg 1 is the first substantive leg.
 In addition to the charter required by the `relay` skill, require that:
 
 - every leg that changes tracked files commits those changes before handoff, following `.agents/skills/changeset-changelog/SKILL.md` for commit and changeset policy;
-- intervention is limited to an unusable environment, destructive-data ambiguity, a business decision outside the charter, a knowingly weakened invariant or security/authorization boundary, unexpected unrelated branch changes, push or pull-request authentication failure, or an infeasible finish line. Ordinary implementation defects and review findings go through remediation legs.
+- the charter includes the Relay method's intervention requirements and any additional trigger explicitly supplied for this relay. Its additional PI WEB triggers are limited to an unusable environment, destructive-data ambiguity, a business decision outside the charter, a knowingly weakened invariant or security/authorization boundary, unexpected unrelated branch changes, push or pull-request authentication failure, or an infeasible finish line. Ordinary implementation defects and review findings go through remediation legs.
 
 ## Before dispatching
 
-Infer the finish line, leg sizing, task-selection policy, and initial sequence when the task provides enough information. Use `ask_user` only when an answer materially changes the goal, target, mode (in-place vs worktree), destructive-data choice, or non-obvious base. Ask at most three questions in one call and include confirmation before dispatch when questions are necessary. Otherwise, write the packet and dispatch leg 1 with one `spawn_session`.
+For PI WEB relays, infer the finish line, leg sizing, task-selection policy, and initial sequence when the task provides enough information. Use `ask_user` only when an answer materially changes the goal, target, mode (in-place vs worktree), destructive-data choice, or non-obvious base. Ask at most three questions in one call and include confirmation before dispatch when questions are necessary. Otherwise, write the packet and dispatch leg 1 with one `spawn_session`.
 
 ## Report back
 

--- a/skills/relay/SKILL.md
+++ b/skills/relay/SKILL.md
@@ -22,38 +22,44 @@ Two consequences follow, and they govern the whole method:
 
 ## The relay packet
 
-A relay is carried by a small packet of documents. By default they live in `.pi-web/relays/<name>/` unless the user or the dispatching prompt says otherwise — always follow an explicit location if given.
+A relay is carried by a small packet of documents. By default, its root is `.pi-web/relays/<name>/`. A user or dispatching instruction may choose another root. Record the actual root in the charter and use it consistently.
 
-Every relay has these three core files:
+Every relay has these three core files.
+
+**Authority follows role, not recency.** The charter is authoritative for where the relay is going and the bounds within which it runs; status is authoritative for where it is now and what comes next; the log is history. A later status update does not override the charter. This split lets every runner adapt the route without silently moving the destination.
 
 **Charter** (`charter.md`) — the stable agreement, written when the relay is planned. It must contain, at minimum:
 
 - **Relay identity.** The relay name and root path, so runners know exactly which relay they are on.
-- **Goal / finish line.** A concrete, achievable end state. Without this the relay runs forever — this is non-negotiable.
+- **Goal / finish line.** A concrete, achievable end state with enough stable boundaries to decide whether it has been reached. The charter must state the finish line. It may define supporting requirements by reference only when it explicitly designates the referenced artifact as part of the stable agreement; neither `status.md` nor `log.md` may be the sole source of what “done” means. Without a finish line the relay runs forever — this is non-negotiable.
 - **Sizing.** How much is *one leg*? This is project- and plan-specific; the charter defines it (a task, a slice, a time/scope budget — whatever fits). The skill does not decide this for you.
 - **Task selection policy.** How a runner chooses the next task when `status.md` does not name one explicitly.
 - **Handover.** How a runner hands off: what the spawn prompt should say and what the next runner must read. A normal handoff starts with a natural header containing the relay name and next leg number, then points at `charter.md` and `status.md`, not the full log.
-- **Intervention signal.** When and how a runner must stop and get the human, and how that is made visible. The charter must define this; the skill does not define it for you.
+- **Intervention signal.** When and how a runner must stop and get the human, and how that is made visible. The charter defines relay-specific triggers and signaling. A runner who would need to change the agreed finish line without explicit human direction must always stop and raise that signal.
 - **Reading discipline.** The files a runner should read to orient, and any files that should not be read defensively.
 
-The charter *can* be edited, but it should rarely *need* to be. If it is changing every leg, that is a smell — the design wasn't settled, or the goal is drifting. Treat frequent charter edits as a reason to stop and involve the human.
+The charter *can* be edited. Clarifications and maintenance are fine, but changing the goal, finish line, or a supporting artifact that the charter designates as part of them changes the relay's agreement; it is not ordinary leg-level adaptation. Runners adapt the route, not the destination. Make such a change only with explicit human agreement, record it in `log.md`, and update the charter before continuing. If you believe the change is needed and do not already have that agreement, stop and raise the intervention signal. Frequent charter edits are still a smell that the design is unsettled.
 
-**Status** (`status.md`) — the compact baton/current state. This is the file every runner reads after the charter, and every runner updates before handoff or stop. Keep it short enough that a fresh runner can load it cheaply. It should answer:
+**Status** (`status.md`) — the compact baton/current state. This is the file every runner reads after the charter, and every runner updates before handoff or stop. Keep it short enough that a fresh runner can load it cheaply.
+
+The baton carries position, not destination. `status.md` is authoritative for current state and next-leg selection only. It may describe a leg task or point to relevant context, but it must fit the charter's finish line and must not redefine, narrow, or extend it. Information needed to judge whether the relay itself is complete needs a stable home in the charter or a supporting artifact the charter designates; status points there rather than becoming its replacement.
+
+It should answer:
 
 - **Current position.** Where the relay is now.
 - **Current or next task.** The next leg if known; otherwise enough information to apply the charter's task selection policy.
-- **Leg tracking.** The last completed leg and the next leg to run. Keep this explicit so runners do not have to infer whether “current leg” means the leg just finished or the leg being handed off, and so new PI-WEB sessions can distinguish relay legs from the first line of their prompt without naming instructions.
+- **Leg tracking.** The last completed leg and the next leg to run. Keep this explicit so runners do not have to infer whether “current leg” means the leg just finished or the leg being handed off, and so the handoff prompt can name the next leg accurately.
 - **Relevant context.** Only the files, sections, commands, artifacts, or specific log entries needed for the next leg.
 - **Progress documentation.** Where this runner must write progress: update `status.md`, append `log.md`, update artifacts, commit, etc.
 - **Blockers / intervention state.** Current risks, open decisions, or active reasons to stop.
 
-Think of `status.md` as the thing passed from runner to runner. If it grows into a history dump, compress it back into current state plus pointers. If an older relay lacks leg tracking, repair it when you update status; prefer the leg number from the prompt or status, and do not read `log.md` end-to-end just to count prior legs.
+Think of `status.md` as the thing passed from runner to runner. If it grows into a history dump, compress it back into current state plus pointers. If finish-line-defining content has crept into status without a stable home, restore it to the charter or a charter-designated artifact before compressing it away. If an older relay lacks leg tracking, repair it when you update status; prefer the leg number from the prompt or status, and do not read `log.md` end-to-end just to count prior legs.
 
-**Log** (`log.md`) — append-only history. Each leg appends a concise entry recording what it did, decisions made and why, durable artifacts changed, status updates made, and blockers. The log preserves auditability, but it is **not** orientation memory.
+**Log** (`log.md`) — append-only history. Each leg appends a concise entry recording what it did, decisions made and why, durable artifacts changed, status updates made, and blockers. The log preserves auditability, including agreed changes to the charter, but it is **not** orientation memory and does not replace the charter as the current agreement.
 
 Do not read `log.md` end-to-end by default. Read targeted log entries only when `status.md` points to them, when the charter requires a specific lookup, or when there is an inconsistency you must resolve before continuing.
 
-Optional files such as `plan.md`, `backlog.md`, or artifact notes are fine, but runners should read them only when the charter/status points to the relevant part.
+Optional files such as `plan.md`, `backlog.md`, specifications, or artifact notes are fine, but runners should read them only when the charter/status points to the relevant part. If the charter designates one as part of the finish line, changing that part follows the same agreement rule as changing the charter itself.
 
 ## Context containment rule
 
@@ -65,22 +71,22 @@ A runner normally reads:
 
 Do not defensively rebuild the relay's full history. Do not read the full log, the full backlog, or a large artifact tree just because they exist. The relay stays scalable because each runner pays only for the context needed now.
 
-If `status.md` is insufficient, fix the baton rather than compensating by reading everything. Use targeted inspection to clarify the current state, update `status.md` so the next runner has a clean start, and continue only if the task is still clear. If reconstructing the state would require broad archaeology or judgment about past intent, stop and raise the intervention signal.
+If `status.md` is insufficient, fix the baton rather than compensating by reading everything. Here, fixing means restoring an accurate account of current state, tasks, and pointers within the charter's bounds; it does not mean reconstructing or revising the finish line in status. Use targeted inspection to clarify the current state, update `status.md` so the next runner has a clean start, and continue only if the task is still clear. If resolving the gap would require broad archaeology or judgment about past intent or what “done” should mean, stop and raise the intervention signal.
 
 ## Running one leg
 
 This is the loop you run when you are dispatched into a relay.
 
-1. **Orient from the packet.** Read `charter.md` and `status.md`. Confirm the relay name/root, goal, sizing, handoff protocol, last completed leg, next leg to run, intervention signal, and current/next task. If you are not sure you are in a relay, the prompt or `.pi-web/relays/` is your clue — and reading this skill means you are.
-2. **Choose the leg.** Prefer the explicit current/next task in `status.md`. If none is named, apply the charter's task selection policy. If that still requires context, inspect only the referenced plan/backlog/artifact sections. If the next task is still ambiguous or would materially change direction, stop and involve the human.
-3. **Re-anchor to the goal.** Does the goal still make sense given the status and what you now see? If reality has diverged from the charter, that is often an intervention moment — don't quietly redefine the task.
+1. **Orient from the packet.** Read `charter.md` and `status.md`. Confirm from the charter the relay identity/root, finish line, sizing, task-selection policy, handoff protocol, intervention signal, and reading discipline. Confirm from status the current position, last completed leg, next leg to run, current/next task, and blockers. If you are not sure you are in a relay, the dispatch prompt or the packet itself is your clue — and reading this skill means you are.
+2. **Choose the leg.** Prefer the explicit current/next task in `status.md`, provided it serves the charter's finish line and fits its sizing. If none is named, apply the charter's task selection policy. If that still requires context, inspect only the referenced plan/backlog/artifact sections. Do not adopt a task merely because status is newer. If the next task is still ambiguous, falls outside the charter's bounds, or would require moving the finish line, stop and involve the human.
+3. **Re-anchor to the charter.** Does the chosen leg still serve the finish line, and does reality still permit it? Adapting how to get there is your job. If reality indicates that what “done” means should change, stop and raise the intervention signal rather than quietly redefining it.
 4. **Run one leg.** Do exactly one well-sized slice, per the charter's sizing. Resist doing "just a bit more" — extra scope bloats context and breaks the containment that makes Relay work.
 5. **Document progress.** Make all work durable. Update `status.md` with the new current state, last completed leg, next leg to run (if any), next task or task-selection pointer, relevant context for the next runner, and blockers. Append a concise `log.md` entry with what you did, why, decisions made, artifacts changed, and whether you are handing off or stopping.
 6. **Decide: hand off, or stop.**
    - **Hand off** if there is a clear next leg and you are on track. Use `spawn_session` once, with a prompt whose first line is a natural task header containing the relay name and next leg number (for example, `Relay "<name>" leg <N> begins now.`), followed by the Relay method and pointers to `charter.md` and `status.md` (so this skill loads and they can orient cheaply). Then you are done. Handoff is deliberately fire-and-forget: `spawn_session` starts an independent session you will not see and cannot steer — do not reach for a tracked subsession to keep an eye on it. Letting go is the point. The next runner is trusted to run their own leg, and the relay packet is the only thread between you; if you feel the need to watch downstream work, that usually means the leg wasn't sized or handed off cleanly, or an intervention signal should have fired.
    - **Stop — do not spawn —** if the goal is reached, or you are blocked, or the charter's intervention signal fires. Update `status.md`, append a clear note in `log.md`, and raise the intervention signal so the watching human sees exactly what happened and what they need to decide. A stalled relay that stopped cleanly with a clear blocker is a success; a relay that spawned a confused next runner is a failure.
 
-A good handoff prompt is short and explicit. Put the relay identity and leg number at the very beginning so PI-WEB's session title generator sees useful distinguishing context without any naming instruction:
+A good handoff prompt is short and explicit. The example below uses the default packet root; substitute the root recorded in the charter when it differs. Put the relay identity and leg number at the very beginning so the hosting UI can derive useful distinguishing context without any naming instruction:
 
 ```text
 Relay "<name>" leg <N> begins now.
@@ -98,17 +104,17 @@ Run one leg according to the charter. Before handing off, update status.md, appe
 
 ## Planning a relay
 
-When the user asks to set up a relay, your job is to produce the relay packet: `charter.md`, `status.md`, and `log.md`. The charter must have the required slots filled: relay identity, goal, sizing, task selection policy, handover, intervention signal, and reading discipline. The initial status must give the first runner a compact baton: current position, leg tracking (usually last completed leg 0 and next leg to run 1 for a new relay), first task or task selection pointer, relevant context, documentation expectations, and known blockers. The log may start empty or with a short seed entry explaining that the relay was created.
+When the user asks to set up a relay, your job is to produce the relay packet: `charter.md`, `status.md`, and `log.md`. The charter must have the required slots filled: relay identity, goal, sizing, task selection policy, handover, intervention signal, and reading discipline. Before dispatch, preserve the agreed finish line and the stable boundaries needed to judge it in the charter or in supporting material the charter explicitly designates. Do not make the initial status or planning conversation the only place those requirements exist. The initial status must give the first runner a compact baton: current position, leg tracking (usually last completed leg 0 and next leg to run 1 for a new relay), first task or task selection pointer, relevant context, documentation expectations, and known blockers. The log may start empty or with a short seed entry explaining that the relay was created.
 
-Draw the required choices out from the user rather than inventing them: ask what the finish line is, how much should be one leg, how runners pick tasks, how runners hand off, what they should read, and when they must stop and get the human. Sizing, task selection, and the intervention signal especially are the user's to decide — propose options if it helps them think, but do not quietly settle them yourself.
+Unless the user or dispatching instructions provide these choices or a rule for deriving them, draw them out from the user rather than inventing them: ask what the finish line is, how much should be one leg, how runners pick tasks, how runners hand off, what they should read, and when they must stop and get the human. Sizing, task selection, and the intervention signal especially are not for the generic method to decide — propose options if it helps, but do not quietly settle them yourself.
 
 Do **not** impose what a "good" plan, leg size, or cadence looks like — those are deeply project-, plan-, and human-specific, and getting them wrong by being prescriptive is worse than leaving them to the user. Your value in planning is making sure the relay is *runnable*: the finish line exists, sizing is stated, task selection is stated, handover is stated, reading discipline is stated, and the intervention signal is stated. Once the packet is agreed, you can dispatch the first leg with `spawn_session`.
 
 ## Smells to watch for
 
-- **No finish line** → infinite relay. Refuse to run a relay without a defined goal.
-- **Goal drift** → each leg quietly restates the task. Re-anchor every leg.
-- **Charter churn** → the charter changes every leg. The design isn't settled; involve the human.
+- **No stable finish line** → infinite or self-redefining relay. Refuse to run when “done” exists only in mutable state.
+- **Goal drift / baton authority creep** → a leg or `status.md` quietly restates, narrows, or extends what the relay is for. Re-anchor to the charter; changing the destination requires human agreement.
+- **Charter churn** → stable policy changes every leg. The design isn't settled; involve the human.
 - **Status bloat** → `status.md` turns into a history dump. Compress it to current state plus targeted pointers.
 - **Defensive reading** → reading the full log/backlog/artifact tree to feel safe. Use the packet and targeted lookups; stop if the baton is not enough.
 - **Eager spawning** → spawning early, spawning several runners, or spawning before work is durable. One leg, one handoff, at the end.


### PR DESCRIPTION
## Summary

- make the charter (and any stable supporting material it designates) authoritative for the Relay finish line
- keep `status.md` as the mutable current-position baton without allowing it to redefine or become the sole source of the goal
- bound baton repair and charter changes while preserving Relay's adaptive, distributed-trust model
- retain standalone Relay defaults and keep PI WEB-specific review, intervention, and worktree instructions in the project prompts
- record whole-work findings and approved HEADs in the append-only log, with status pointing to those records

## Verification

- pre-commit `npm run verify:staged`: cached whole-project typecheck passed; Knip passed; no staged files required ESLint or related Vitest coverage
- `git diff --check origin/main...HEAD`
- `npm exec --yes skills -- add ./skills/relay --list`: local path validated and the `relay` skill was discovered
- Pi prompt loader discovered `relay` and `relay-worktree` with no relevant diagnostics

No Changeset: these repository-only skill and prompt files are outside the published npm package allowlist.
