### PR TITLE
feat: color session tree kind badges

### DIFF
--- a/.changeset/color-session-tree-kind-badges.md
+++ b/.changeset/color-session-tree-kind-badges.md
@@ -1,0 +1,5 @@
+---
+"@jmfederico/pi-web": patch
+---
+
+Add semantic colors to session-tree kind badges so conversation entry types are easier to distinguish.

--- a/src/client/src/components/SessionTreeNavigator.test.ts
+++ b/src/client/src/components/SessionTreeNavigator.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { SessionTreeForkResult, SessionTreeNavigateResult, SessionTreeSnapshot, SessionTreeSummaryChoice } from "../api";
-import { SessionTreeNavigator, sessionTreeEntryReturnsToEditor, sessionTreeVisualDepth } from "./SessionTreeNavigator";
+import type { SessionTreeForkResult, SessionTreeNavigateResult, SessionTreeNodeKind, SessionTreeSnapshot, SessionTreeSummaryChoice } from "../api";
+import { SessionTreeNavigator, sessionTreeEntryReturnsToEditor, sessionTreeKindPresentation, sessionTreeVisualDepth } from "./SessionTreeNavigator";
 
 type NavigateCallback = (targetId: string, summaryChoice: SessionTreeSummaryChoice) => Promise<SessionTreeNavigateResult>;
 type ForkCallback = (entryId: string) => Promise<SessionTreeForkResult>;
@@ -33,6 +33,26 @@ describe("session-tree-navigator location step", () => {
     expect(shadowText(navigator)).toContain("does not contain any selectable history entries");
     expect(footerLabels(navigator)).toEqual(["Cancel", "Next"]);
     expect(footerButton(navigator, "Next").disabled).toBe(true);
+  });
+
+  it("uses the same semantic kind badge treatment in the tree and selected-entry steps", async () => {
+    const navigator = await mountNavigator();
+    const root = treeItem(navigator, "root");
+    root.click();
+    await settle(navigator);
+
+    const treeBadge = kindBadge(root);
+    expect(treeBadge.textContent).toBe("User");
+    expect(treeBadge.classList.contains("kind-tone-user")).toBe(true);
+    expect(root.classList.contains("kind-tone-user")).toBe(false);
+
+    await advanceToAction(navigator);
+    const selectedEntry = navigator.renderRoot.querySelector(".selected-entry");
+    if (!(selectedEntry instanceof HTMLElement)) throw new Error("Selected entry was unavailable");
+    const actionBadge = kindBadge(selectedEntry);
+    expect(actionBadge.textContent).toBe("User");
+    expect(actionBadge.classList.contains("kind-tone-user")).toBe(true);
+    expect(selectedEntry.classList.contains("kind-tone-user")).toBe(false);
   });
 
   it("ignores f and F but advances with Enter", async () => {
@@ -290,6 +310,40 @@ describe("session-tree-navigator action step", () => {
 });
 
 describe("session-tree-navigator display helpers", () => {
+  it("maps every node kind to its semantic badge treatment and readable label", () => {
+    const actual: Record<SessionTreeNodeKind, ReturnType<typeof sessionTreeKindPresentation>> = {
+      user: sessionTreeKindPresentation("user"),
+      assistant: sessionTreeKindPresentation("assistant"),
+      "tool-result": sessionTreeKindPresentation("tool-result"),
+      bash: sessionTreeKindPresentation("bash"),
+      "custom-message": sessionTreeKindPresentation("custom-message"),
+      compaction: sessionTreeKindPresentation("compaction"),
+      "branch-summary": sessionTreeKindPresentation("branch-summary"),
+      "model-change": sessionTreeKindPresentation("model-change"),
+      "thinking-level-change": sessionTreeKindPresentation("thinking-level-change"),
+      "session-info": sessionTreeKindPresentation("session-info"),
+      label: sessionTreeKindPresentation("label"),
+      custom: sessionTreeKindPresentation("custom"),
+      other: sessionTreeKindPresentation("other"),
+    };
+
+    expect(actual).toEqual({
+      user: { label: "User", tone: "user", bookkeeping: false },
+      assistant: { label: "Assistant", tone: "assistant", bookkeeping: false },
+      "tool-result": { label: "Tool result", tone: "tool", bookkeeping: false },
+      bash: { label: "Shell", tone: "shell", bookkeeping: false },
+      "custom-message": { label: "Custom message", tone: "context", bookkeeping: false },
+      compaction: { label: "Compaction", tone: "context", bookkeeping: false },
+      "branch-summary": { label: "Branch summary", tone: "context", bookkeeping: false },
+      "model-change": { label: "Model", tone: "metadata", bookkeeping: true },
+      "thinking-level-change": { label: "Thinking", tone: "metadata", bookkeeping: true },
+      "session-info": { label: "Session info", tone: "metadata", bookkeeping: true },
+      label: { label: "Label", tone: "metadata", bookkeeping: true },
+      custom: { label: "Custom", tone: "metadata", bookkeeping: true },
+      other: { label: "Other", tone: "metadata", bookkeeping: true },
+    });
+  });
+
   it("describes Pi's editor-return semantics and bounds pathological visual indentation", () => {
     expect(sessionTreeEntryReturnsToEditor("user")).toBe(true);
     expect(sessionTreeEntryReturnsToEditor("custom-message")).toBe(true);
@@ -344,6 +398,12 @@ function treeItem(navigator: SessionTreeNavigator, id: string): HTMLElement {
   const item = navigator.renderRoot.querySelector(`[data-tree-node-id='${id}']`);
   if (!(item instanceof HTMLElement)) throw new Error(`Tree item "${id}" was unavailable`);
   return item;
+}
+
+function kindBadge(container: ParentNode): HTMLElement {
+  const badge = container.querySelector(".kind");
+  if (!(badge instanceof HTMLElement)) throw new Error("Kind badge was unavailable");
+  return badge;
 }
 
 function closeButton(navigator: SessionTreeNavigator): HTMLButtonElement {

--- a/src/client/src/components/SessionTreeNavigator.ts
+++ b/src/client/src/components/SessionTreeNavigator.ts
@@ -10,6 +10,30 @@ type NavigatorStep = "tree" | "action";
 type NavigatorOperation = "continue" | "fork";
 type PendingFocus = "tree" | "operation" | "summary" | "custom";
 
+export type SessionTreeKindTone = "user" | "assistant" | "tool" | "shell" | "context" | "metadata";
+
+export interface SessionTreeKindPresentation {
+  readonly label: string;
+  readonly tone: SessionTreeKindTone;
+  readonly bookkeeping: boolean;
+}
+
+const SESSION_TREE_KIND_PRESENTATION = {
+  user: { label: "User", tone: "user", bookkeeping: false },
+  assistant: { label: "Assistant", tone: "assistant", bookkeeping: false },
+  "tool-result": { label: "Tool result", tone: "tool", bookkeeping: false },
+  bash: { label: "Shell", tone: "shell", bookkeeping: false },
+  "custom-message": { label: "Custom message", tone: "context", bookkeeping: false },
+  compaction: { label: "Compaction", tone: "context", bookkeeping: false },
+  "branch-summary": { label: "Branch summary", tone: "context", bookkeeping: false },
+  "model-change": { label: "Model", tone: "metadata", bookkeeping: true },
+  "thinking-level-change": { label: "Thinking", tone: "metadata", bookkeeping: true },
+  "session-info": { label: "Session info", tone: "metadata", bookkeeping: true },
+  label: { label: "Label", tone: "metadata", bookkeeping: true },
+  custom: { label: "Custom", tone: "metadata", bookkeeping: true },
+  other: { label: "Other", tone: "metadata", bookkeeping: true },
+} as const satisfies Record<SessionTreeNodeKind, SessionTreeKindPresentation>;
+
 @customElement("session-tree-navigator")
 export class SessionTreeNavigator extends LitElement {
   @property({ attribute: false }) tree: SessionTreeSnapshot = EMPTY_TREE;
@@ -100,12 +124,13 @@ export class SessionTreeNavigator extends LitElement {
   private renderTreeRow(row: SessionTreeRow): TemplateResult {
     const selected = row.node.id === this.selectedId;
     const expanded = row.childIds.length > 0 && !this.foldedIds.has(row.node.id);
+    const kindPresentation = sessionTreeKindPresentation(row.node.kind);
     const classes = [
       "tree-row",
       selected ? "selected" : "",
       row.activePath ? "active-path" : "",
       row.activeLeaf ? "active-leaf" : "",
-      isBookkeepingKind(row.node.kind) ? "bookkeeping" : "",
+      kindPresentation.bookkeeping ? "bookkeeping" : "",
     ].filter((value) => value !== "").join(" ");
     const visualDepth = sessionTreeVisualDepth(row.branchDepth);
     return html`
@@ -129,7 +154,7 @@ export class SessionTreeNavigator extends LitElement {
           @click=${(event: MouseEvent) => { this.toggleNode(row.node.id, event); }}
         >${row.childIds.length === 0 ? "·" : expanded ? "▾" : "▸"}</span>
         <span class="metadata">
-          <span class="kind">${sessionTreeKindLabel(row.node.kind)}</span>
+          ${this.renderKindBadge(kindPresentation)}
           <span class="badges">
             ${row.activePath && !row.activeLeaf ? html`<span class="badge path">Active path</span>` : null}
             ${row.activeLeaf ? html`<span class="badge leaf">Active leaf</span>` : null}
@@ -144,6 +169,10 @@ export class SessionTreeNavigator extends LitElement {
     `;
   }
 
+  private renderKindBadge(presentation: SessionTreeKindPresentation): TemplateResult {
+    return html`<span class=${`kind kind-tone-${presentation.tone}`}>${presentation.label}</span>`;
+  }
+
   private renderActionStep(): TemplateResult {
     const selectedNode = this.selectedId === undefined ? undefined : this.model.nodesById.get(this.selectedId);
     const validation = validateSessionTreeSummaryChoice(this.summaryMode, this.customInstructions);
@@ -156,7 +185,7 @@ export class SessionTreeNavigator extends LitElement {
           </div>
           ${selectedNode === undefined ? html`<div class="empty">The selected history entry is no longer available.</div>` : html`
             <div class="selected-entry">
-              <span class="kind">${sessionTreeKindLabel(selectedNode.kind)}</span>
+              ${this.renderKindBadge(sessionTreeKindPresentation(selectedNode.kind))}
               <strong dir="auto">${selectedNode.summary}</strong>
               <p>${this.selectedEntryDescription(selectedNode.kind)}</p>
             </div>
@@ -554,7 +583,13 @@ export class SessionTreeNavigator extends LitElement {
     .tree-row > .metadata > .kind { grid-column: 2; grid-row: 1; }
     .tree-row > .entry { grid-column: 3; grid-row: 1; }
     .tree-row > .metadata > .badges { grid-column: 4; grid-row: 1; }
-    .kind { display: inline-flex; align-items: center; width: fit-content; border: 1px solid var(--pi-border); border-radius: 999px; padding: 2px 7px; color: var(--pi-muted); background: var(--pi-bg); font-size: 11px; font-weight: 700; white-space: nowrap; }
+    .kind { --kind-border: var(--pi-border); --kind-background: var(--pi-surface); display: inline-flex; align-items: center; width: fit-content; border: 1px solid var(--kind-border); border-radius: 999px; padding: 2px 7px; color: var(--pi-text); background: var(--kind-background); font-size: 11px; font-weight: 700; white-space: nowrap; }
+    .kind-tone-user { --kind-border: var(--pi-accent-border); --kind-background: var(--pi-selection-bg); }
+    .kind-tone-assistant { --kind-border: var(--pi-border); --kind-background: var(--pi-surface); }
+    .kind-tone-tool { --kind-border: var(--pi-warning-border); --kind-background: var(--pi-warning-surface); }
+    .kind-tone-shell { --kind-border: var(--pi-success); --kind-background: var(--pi-success-bg); }
+    .kind-tone-context { --kind-border: var(--pi-purple-border); --kind-background: var(--pi-purple-surface); }
+    .kind-tone-metadata { --kind-border: var(--pi-border-muted); --kind-background: var(--pi-bg-overlay); color: var(--pi-muted); }
     .entry { min-width: 0; display: flex; align-items: baseline; gap: 8px; }
     .summary { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--pi-text); }
     .bookkeeping .summary { color: var(--pi-muted); }
@@ -619,31 +654,8 @@ export function sessionTreeEntryReturnsToEditor(kind: SessionTreeNodeKind): bool
   return kind === "user" || kind === "custom-message";
 }
 
-export function sessionTreeKindLabel(kind: SessionTreeNodeKind): string {
-  switch (kind) {
-    case "user": return "User";
-    case "assistant": return "Assistant";
-    case "tool-result": return "Tool result";
-    case "bash": return "Shell";
-    case "custom-message": return "Custom message";
-    case "compaction": return "Compaction";
-    case "branch-summary": return "Branch summary";
-    case "model-change": return "Model";
-    case "thinking-level-change": return "Thinking";
-    case "session-info": return "Session info";
-    case "label": return "Label";
-    case "custom": return "Custom";
-    case "other": return "Other";
-  }
-}
-
-function isBookkeepingKind(kind: SessionTreeNodeKind): boolean {
-  return kind === "model-change"
-    || kind === "thinking-level-change"
-    || kind === "session-info"
-    || kind === "label"
-    || kind === "custom"
-    || kind === "other";
+export function sessionTreeKindPresentation(kind: SessionTreeNodeKind): SessionTreeKindPresentation {
+  return SESSION_TREE_KIND_PRESENTATION[kind];
 }
 
 function errorMessage(error: unknown): string {


### PR DESCRIPTION
## Summary

- Give each session-tree entry kind a semantic, theme-aware badge treatment so users can distinguish message, tool, shell, auxiliary-context, and metadata entries faster.
- Reuse the same exhaustive client-side kind presentation and badge renderer in both tree rows and the action-step selected-entry detail.
- Keep colour confined to readable kind badges while preserving labels, selection/focus styling, active-path and active-leaf markers, and ARIA state.
- Add focused regression coverage and a patch Changeset.

## Behavioral and contract impact

This is a visual client-side enhancement only. Every kind retains its text label, and colour remains a redundant cue. The implementation reuses existing PI WEB theme tokens and does not change API/model fields, server or session-daemon behavior, the theme/plugin contract, or infer error status from summary text.

## Migration and deployment

No migration or coordinated deployment ordering is required. This ships with the ordinary web client; no session-daemon restart is needed.

## Verification

- `npm run verify` with ambient npm `10.9.8`: **failed** only in unchanged `src/buildContents.test.ts` after typecheck, ESLint, and Knip passed, because npm 10 unexpectedly ran the fixture `prepare` script despite `npm pack --ignore-scripts`. The repository declares `packageManager: npm@11.11.0`.
- `/usr/bin/corepack npm test -- --run src/buildContents.test.ts` with npm `11.11.0`: **passed** (1 file, 2 tests).
- `/usr/bin/corepack npm run verify` with npm `11.11.0`: **passed** typecheck, ESLint, Knip, and Vitest (270 files; 2447 tests passed; 2 Windows-only tests skipped on Linux in `src/server/workingDirectory.test.ts`).
- `/usr/bin/corepack npm test -- --run src/client/src/components/SessionTreeNavigator.test.ts`: **passed** (1 file, 16 tests).
- `/usr/bin/corepack npm run typecheck`: **passed**.
- `git diff --check 5f6073fdb40f823e6fc4952f5ad08e8dfd301b0d..4471e808b9868c1d073161ddefe4883ef78689b9`: **passed**.
