### PR TITLE
feat(session): support Pi scoped models

### DIFF
--- a/.changeset/honor-pi-scoped-models.md
+++ b/.changeset/honor-pi-scoped-models.md
@@ -1,0 +1,5 @@
+---
+"@jmfederico/pi-web": patch
+---
+
+Honor pi's global and project `enabledModels` settings in session model selection and cycling.

--- a/src/server/sessions/piSessionService.ts
+++ b/src/server/sessions/piSessionService.ts
@@ -81,6 +81,7 @@ import {
 } from "./sessionNotificationStore.js";
 import { plainTextTheme } from "./plainTextTheme.js";
 import { SessionUnreadStore, type SessionUnreadMutation } from "./sessionUnreadStore.js";
+import { resolveSessionModelOptions } from "./sessionModelScope.js";
 
 /**
  * Minimal structured-logging seam, shaped like Fastify's logger so sessiond can
@@ -741,6 +742,13 @@ function createDefaultRuntimeFactory(
       modelRuntime,
       ...(resourceLoaderOptions === undefined ? {} : { resourceLoaderOptions }),
     });
+    const modelOptions = await resolveSessionModelOptions({
+      services,
+      hasExistingSession: sessionManager.buildSessionContext().messages.length > 0,
+      ...(initialModel === undefined ? {} : { initialModel }),
+      ...(initialThinkingLevel === undefined ? {} : { initialThinkingLevel }),
+    });
+    services.diagnostics.push(...modelOptions.diagnostics);
     const resolvedDelegationToolsEnabled = delegationToolsEnabled
       ?? await sessionAllowsDelegationTools(sessionManager, sessionManagers);
     const customTools = createPiWebCustomToolDefinitions(cwd, resolvedDelegationToolsEnabled, spawn, subsessions, askUser);
@@ -749,8 +757,9 @@ function createDefaultRuntimeFactory(
       sessionManager,
       customTools,
       ...(sessionStartEvent === undefined ? {} : { sessionStartEvent }),
-      ...(initialModel === undefined ? {} : { model: initialModel }),
-      ...(initialThinkingLevel === undefined ? {} : { thinkingLevel: initialThinkingLevel }),
+      ...(modelOptions.model === undefined ? {} : { model: modelOptions.model }),
+      ...(modelOptions.thinkingLevel === undefined ? {} : { thinkingLevel: modelOptions.thinkingLevel }),
+      ...(modelOptions.scopedModels.length === 0 ? {} : { scopedModels: modelOptions.scopedModels }),
     });
     return { ...result, services, diagnostics: services.diagnostics };
   };

--- a/src/server/sessions/sessionModelScope.test.ts
+++ b/src/server/sessions/sessionModelScope.test.ts
@@ -1,0 +1,175 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { InMemoryCredentialStore } from "@earendil-works/pi-ai";
+import { ModelRuntime, SessionManager, SettingsManager } from "@earendil-works/pi-coding-agent";
+import { afterEach, beforeAll, describe, expect, it } from "vitest";
+import { PiSessionService } from "./piSessionService.js";
+import { CapturingSessionEventHub, sessionGateway } from "./piSessionService.testSupport.js";
+import { resolveSessionModelOptions } from "./sessionModelScope.js";
+
+const PROVIDER = "anthropic";
+const FIRST_MODEL = "claude-opus-4-6";
+const DEFAULT_MODEL = "claude-sonnet-4-5";
+
+let modelRuntime: ModelRuntime;
+const tempDirs: string[] = [];
+
+beforeAll(async () => {
+  const credentials = new InMemoryCredentialStore();
+  await credentials.modify(PROVIDER, () => Promise.resolve({ type: "api_key", key: "sk-test" }));
+  modelRuntime = await ModelRuntime.create({ credentials, modelsPath: null, allowModelNetwork: false });
+});
+
+afterEach(async () => {
+  await Promise.all(tempDirs.splice(0).map((path) => rm(path, { recursive: true, force: true })));
+});
+
+function services(settings: { enabledModels?: string[]; defaultProvider?: string; defaultModel?: string }) {
+  return {
+    modelRuntime,
+    settingsManager: SettingsManager.inMemory(settings),
+  };
+}
+
+describe("resolveSessionModelOptions", () => {
+  it("preserves configured scope order and selects an in-scope saved default", async () => {
+    const resolved = await resolveSessionModelOptions({
+      services: services({
+        enabledModels: [`${PROVIDER}/${FIRST_MODEL}:high`, `${PROVIDER}/${DEFAULT_MODEL}:low`],
+        defaultProvider: PROVIDER,
+        defaultModel: DEFAULT_MODEL,
+      }),
+      hasExistingSession: false,
+    });
+
+    expect(resolved.scopedModels.map(({ model, thinkingLevel }) => ({ id: model.id, thinkingLevel }))).toEqual([
+      { id: FIRST_MODEL, thinkingLevel: "high" },
+      { id: DEFAULT_MODEL, thinkingLevel: "low" },
+    ]);
+    expect(resolved.model?.id).toBe(DEFAULT_MODEL);
+    expect(resolved.thinkingLevel).toBe("low");
+    expect(resolved.diagnostics).toEqual([]);
+  });
+
+  it("uses the first scoped model and its pinned thinking when the saved default is outside scope", async () => {
+    const resolved = await resolveSessionModelOptions({
+      services: services({
+        enabledModels: [`${PROVIDER}/${FIRST_MODEL}:high`],
+        defaultProvider: PROVIDER,
+        defaultModel: DEFAULT_MODEL,
+      }),
+      hasExistingSession: false,
+    });
+
+    expect(resolved.model?.id).toBe(FIRST_MODEL);
+    expect(resolved.thinkingLevel).toBe("high");
+  });
+
+  it("keeps an explicit model and thinking level while still populating the cycle scope", async () => {
+    const explicitModel = modelRuntime.getModel(PROVIDER, DEFAULT_MODEL);
+    if (explicitModel === undefined) throw new Error("expected explicit model fixture");
+
+    const resolved = await resolveSessionModelOptions({
+      services: services({ enabledModels: [`${PROVIDER}/${FIRST_MODEL}:high`] }),
+      hasExistingSession: false,
+      initialModel: explicitModel,
+      initialThinkingLevel: "minimal",
+    });
+
+    expect(resolved.model).toBe(explicitModel);
+    expect(resolved.thinkingLevel).toBe("minimal");
+    expect(resolved.scopedModels.map(({ model }) => model.id)).toEqual([FIRST_MODEL]);
+  });
+
+  it("leaves the initial model unset for an existing session so pi can restore it", async () => {
+    const resolved = await resolveSessionModelOptions({
+      services: services({ enabledModels: [`${PROVIDER}/${FIRST_MODEL}:high`] }),
+      hasExistingSession: true,
+    });
+
+    expect(resolved.model).toBeUndefined();
+    expect(resolved.thinkingLevel).toBeUndefined();
+    expect(resolved.scopedModels.map(({ model }) => model.id)).toEqual([FIRST_MODEL]);
+  });
+
+  it("keeps an empty runtime scope when enabledModels is absent", async () => {
+    await expect(resolveSessionModelOptions({
+      services: services({}),
+      hasExistingSession: false,
+    })).resolves.toEqual({ scopedModels: [], diagnostics: [] });
+  });
+
+  it("reports unmatched patterns without blocking startup or inventing a scope", async () => {
+    const resolved = await resolveSessionModelOptions({
+      services: services({ enabledModels: ["anthropic/not-a-real-model"] }),
+      hasExistingSession: false,
+    });
+
+    expect(resolved.scopedModels).toEqual([]);
+    expect(resolved.model).toBeUndefined();
+    expect(resolved.diagnostics).toEqual([{
+      type: "warning",
+      message: 'No models match pattern "anthropic/not-a-real-model"',
+    }]);
+  });
+
+  it("keeps a matched model while surfacing an invalid pinned thinking level", async () => {
+    const pattern = `${PROVIDER}/${FIRST_MODEL}:turbo`;
+    const resolved = await resolveSessionModelOptions({
+      services: services({ enabledModels: [pattern] }),
+      hasExistingSession: false,
+    });
+
+    expect(resolved.scopedModels.map(({ model }) => model.id)).toEqual([FIRST_MODEL]);
+    expect(resolved.scopedModels[0]?.thinkingLevel).toBeUndefined();
+    expect(resolved.diagnostics).toEqual([{
+      type: "warning",
+      message: `Invalid thinking level "turbo" in pattern "${pattern}". Using default instead.`,
+    }]);
+  });
+
+  it("wires project-overridden enabledModels into real PI WEB sessions", async () => {
+    const root = await mkdtemp(join(tmpdir(), "pi-web-model-scope-"));
+    tempDirs.push(root);
+    const agentDir = join(root, "agent");
+    const workspace = join(root, "workspace");
+    await mkdir(join(workspace, ".pi"), { recursive: true });
+    await mkdir(agentDir, { recursive: true });
+    await writeFile(join(agentDir, "settings.json"), JSON.stringify({
+      enabledModels: [`${PROVIDER}/${FIRST_MODEL}`],
+    }));
+    await writeFile(join(workspace, ".pi", "settings.json"), JSON.stringify({
+      enabledModels: [`${PROVIDER}/${FIRST_MODEL}:high`, `${PROVIDER}/${DEFAULT_MODEL}:low`],
+      defaultProvider: PROVIDER,
+      defaultModel: DEFAULT_MODEL,
+    }));
+
+    const gateway = sessionGateway([]);
+    gateway.create = (cwd) => SessionManager.inMemory(cwd);
+    const service = new PiSessionService(new CapturingSessionEventHub(), {
+      agentDir,
+      modelRuntime,
+      sessionManager: gateway,
+      heartbeatIntervalMs: 60_000,
+    });
+
+    try {
+      const created = await service.start(workspace);
+      await expect(service.availableModels({ id: created.id, cwd: workspace })).resolves.toEqual([
+        expect.objectContaining({ provider: PROVIDER, id: FIRST_MODEL }),
+        expect.objectContaining({ provider: PROVIDER, id: DEFAULT_MODEL }),
+      ]);
+      await expect(service.status({ id: created.id, cwd: workspace })).resolves.toMatchObject({
+        model: { provider: PROVIDER, id: DEFAULT_MODEL },
+        thinkingLevel: "low",
+      });
+      await expect(service.cycleModel({ id: created.id, cwd: workspace }, "forward")).resolves.toMatchObject({
+        model: { provider: PROVIDER, id: FIRST_MODEL },
+        thinkingLevel: "high",
+      });
+    } finally {
+      await service.dispose();
+    }
+  });
+});

--- a/src/server/sessions/sessionModelScope.ts
+++ b/src/server/sessions/sessionModelScope.ts
@@ -1,0 +1,76 @@
+import { modelsAreEqual } from "@earendil-works/pi-ai";
+import type { ThinkingLevel } from "@earendil-works/pi-agent-core";
+import {
+  resolveModelScopeWithDiagnostics,
+  type AgentSessionRuntimeDiagnostic,
+  type ExtensionContext,
+  type ModelRuntime,
+  type ScopedModel,
+  type SettingsManager,
+} from "@earendil-works/pi-coding-agent";
+
+type SessionModel = NonNullable<ExtensionContext["model"]>;
+
+interface ResolveSessionModelOptionsInput {
+  services: {
+    modelRuntime: ModelRuntime;
+    settingsManager: Pick<SettingsManager, "getDefaultModel" | "getDefaultProvider" | "getEnabledModels">;
+  };
+  hasExistingSession: boolean;
+  initialModel?: SessionModel;
+  initialThinkingLevel?: ThinkingLevel;
+}
+
+export interface ResolvedSessionModelOptions {
+  scopedModels: ScopedModel[];
+  diagnostics: AgentSessionRuntimeDiagnostic[];
+  model?: SessionModel;
+  thinkingLevel?: ThinkingLevel;
+}
+
+/** Resolve pi's cwd-bound cycling scope without overriding explicit or restored session state. */
+export async function resolveSessionModelOptions(input: ResolveSessionModelOptionsInput): Promise<ResolvedSessionModelOptions> {
+  const patterns = input.services.settingsManager.getEnabledModels();
+  const resolved = patterns !== undefined && patterns.length > 0
+    ? await resolveModelScopeWithDiagnostics(patterns, input.services.modelRuntime)
+    : { scopedModels: [], diagnostics: [] };
+  const diagnostics: AgentSessionRuntimeDiagnostic[] = resolved.diagnostics.map((diagnostic) => ({
+    type: diagnostic.type,
+    message: diagnostic.message,
+  }));
+
+  if (input.initialModel !== undefined) {
+    return {
+      scopedModels: resolved.scopedModels,
+      diagnostics,
+      model: input.initialModel,
+      ...(input.initialThinkingLevel === undefined ? {} : { thinkingLevel: input.initialThinkingLevel }),
+    };
+  }
+  if (input.hasExistingSession || resolved.scopedModels.length === 0) {
+    return {
+      scopedModels: resolved.scopedModels,
+      diagnostics,
+      ...(input.initialThinkingLevel === undefined ? {} : { thinkingLevel: input.initialThinkingLevel }),
+    };
+  }
+
+  const defaultProvider = input.services.settingsManager.getDefaultProvider();
+  const defaultModelId = input.services.settingsManager.getDefaultModel();
+  const defaultModel = defaultProvider !== undefined && defaultModelId !== undefined
+    ? input.services.modelRuntime.getModel(defaultProvider, defaultModelId)
+    : undefined;
+  const selected = defaultModel === undefined
+    ? resolved.scopedModels[0]
+    : resolved.scopedModels.find((candidate) => modelsAreEqual(candidate.model, defaultModel)) ?? resolved.scopedModels[0];
+  if (selected === undefined) throw new Error("Scoped model resolution returned an empty selection");
+
+  return {
+    scopedModels: resolved.scopedModels,
+    diagnostics,
+    model: selected.model,
+    ...(input.initialThinkingLevel !== undefined
+      ? { thinkingLevel: input.initialThinkingLevel }
+      : selected.thinkingLevel === undefined ? {} : { thinkingLevel: selected.thinkingLevel }),
+  };
+}


### PR DESCRIPTION
## Motivation

Pi supports cwd-aware `enabledModels` settings, but PI WEB did not pass the resolved scope into SDK sessions. As a result, its model picker, cycling, and new-session defaults could differ from pi for the same workspace.

## Changes

- Resolve global and project `enabledModels` for each session's effective cwd.
- Pass scoped models and resolution diagnostics into the Pi session runtime.
- Select an in-scope saved default for new sessions, falling back to the first scoped model.
- Preserve explicit spawn/subsession model choices and existing-session restoration.
- Keep scoped models as picker/cycling behavior rather than an authorization boundary.
- Add regression coverage and a patch Changeset for the user-visible capability.
