### PR TITLE
fix(cli): service readiness — doctor exit code and launchd restart settle/readiness gates (#151, #152)

### DIFF
--- a/.changeset/doctor-running-components-exit-code.md
+++ b/.changeset/doctor-running-components-exit-code.md
@@ -1,0 +1,5 @@
+---
+"@jmfederico/pi-web": patch
+---
+
+Make `pi-web doctor` exit nonzero when an installed Web/UI or session daemon component is unavailable or stale (restart needed), instead of only reporting it in the version section. Machines with no PI WEB services installed keep the previous informational behavior.

--- a/.changeset/restart-service-readiness-gate.md
+++ b/.changeset/restart-service-readiness-gate.md
@@ -1,0 +1,5 @@
+---
+"@jmfederico/pi-web": patch
+---
+
+Fix `pi-web restart` on macOS reporting success while LaunchAgents could disappear: the CLI now waits for each `launchctl bootout` to finish unloading before re-bootstrapping the service instead of racing launchd's asynchronous teardown, and the install path settles the same way. `pi-web start` and `pi-web restart` now also verify on macOS and Linux that each service is actually running and responsive (web/API endpoint, session daemon health), exiting nonzero and naming the unready service instead of succeeding silently.

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -5,6 +5,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   commandWithVersionCheck,
   doctorExitCode,
+  expectedRunningComponents,
   generalDoctorChecks,
   isCliEntrypoint,
   launchdRuntimeDetails,
@@ -13,6 +14,7 @@ import {
   serviceBackendForPlatform,
   sessionDaemonRestartPlan,
 } from "./cli.js";
+import type { NativeServiceId } from "./nativeServices/servicePlan.js";
 
 const originalShell = process.env["SHELL"];
 const originalPiWebConfig = process.env["PI_WEB_CONFIG"];
@@ -85,11 +87,12 @@ describe("native-service doctor CLI contracts", () => {
     expect(serviceBackendForPlatform("win32")).toBeUndefined();
   });
 
-  it("fails doctor for general, native-plan, or node-pty failures", () => {
-    expect(doctorExitCode(true, true, true)).toBe(0);
-    expect(doctorExitCode(false, true, true)).toBe(1);
-    expect(doctorExitCode(true, false, true)).toBe(1);
-    expect(doctorExitCode(true, true, false)).toBe(1);
+  it("fails doctor for general, native-plan, node-pty, or running-component failures", () => {
+    expect(doctorExitCode(true, true, true, true)).toBe(0);
+    expect(doctorExitCode(false, true, true, true)).toBe(1);
+    expect(doctorExitCode(true, false, true, true)).toBe(1);
+    expect(doctorExitCode(true, true, false, true)).toBe(1);
+    expect(doctorExitCode(true, true, true, false)).toBe(1);
   });
 
   it("accepts only regular files as bundled entrypoints", () => {
@@ -111,6 +114,35 @@ describe("native-service doctor CLI contracts", () => {
       detail: "exited (last exit code 127)",
       pid: undefined,
     });
+  });
+});
+
+describe("expectedRunningComponents", () => {
+  it("expects nothing when no services are installed outside Docker", () => {
+    expect(expectedRunningComponents(new Set<NativeServiceId>(), {})).toEqual([]);
+  });
+
+  it("expects web and sessiond for a production install", () => {
+    expect(expectedRunningComponents(new Set<NativeServiceId>(["sessiond", "web"]), {})).toEqual(["web", "sessiond"]);
+  });
+
+  it("expects web and sessiond for a development install", () => {
+    expect(expectedRunningComponents(new Set<NativeServiceId>(["sessiond", "uiDev"]), {})).toEqual(["web", "sessiond"]);
+  });
+
+  it("expects only the components whose services are installed", () => {
+    expect(expectedRunningComponents(new Set<NativeServiceId>(["sessiond"]), {})).toEqual(["sessiond"]);
+    expect(expectedRunningComponents(new Set<NativeServiceId>(["web"]), {})).toEqual(["web"]);
+    expect(expectedRunningComponents(new Set<NativeServiceId>(["uiDev"]), {})).toEqual(["web"]);
+  });
+
+  it("expects both components for a Docker runtime regardless of native service files", () => {
+    expect(expectedRunningComponents(new Set<NativeServiceId>(), { PI_WEB_DOCKER_RUNTIME: "1" })).toEqual(["web", "sessiond"]);
+    expect(expectedRunningComponents(new Set<NativeServiceId>(["sessiond"]), { PI_WEB_DOCKER_RUNTIME: "1", PI_WEB_DOCKER_MODE: "dev" })).toEqual(["web", "sessiond"]);
+  });
+
+  it("treats a falsy Docker runtime marker as no Docker runtime", () => {
+    expect(expectedRunningComponents(new Set<NativeServiceId>(), { PI_WEB_DOCKER_RUNTIME: "0" })).toEqual([]);
   });
 });
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,7 +8,7 @@ import { fileURLToPath } from "node:url";
 import { defaultPiWebConfigPath, defaultPiWebDataDir, examplePiWebConfig } from "./config.js";
 import { piWebDockerCommand, type PiWebDockerMode } from "./docker/piWebDockerCommandPlan.js";
 import { runPluginRecoveryCli, type SessionDaemonRestartPlan } from "./pluginRecoveryCli.js";
-import { packageVersion, printPiWebVersionReport } from "./piWebVersionReport.js";
+import { packageVersion, printPiWebVersionReport, runningComponentsReady, type RunningComponentId } from "./piWebVersionReport.js";
 import { checkNodePtyDarwinSpawnHelper, formatNodePtyDarwinSpawnHelperCheck } from "./server/diagnostics/nodePtySpawnHelper.js";
 import { checkNodePtyNativeModule, formatNodePtyNativeModuleCheck } from "./server/diagnostics/nodePtyNativeModule.js";
 import {
@@ -1037,12 +1037,33 @@ function printPathSetupAdvice(shell: NativeServiceShell = detectServiceShell()):
   }
 }
 
+/**
+ * Running components an installed deployment must keep ready: the API-serving
+ * component whenever the web or UI dev service file is installed (the version
+ * endpoint probes the API port in both modes), and the session daemon whenever
+ * its service file is installed. Docker deployments have no native service
+ * files, so the Docker runtime marker expects both components. A machine with
+ * nothing installed expects nothing: doctor's manual-run guidance stays a
+ * passing outcome there.
+ */
+export function expectedRunningComponents(
+  installedServices: ReadonlySet<NativeServiceId>,
+  env: NodeJS.ProcessEnv,
+): RunningComponentId[] {
+  if (activeDockerMode(env) !== undefined) return ["web", "sessiond"];
+  const expected: RunningComponentId[] = [];
+  if (installedServices.has("web") || installedServices.has("uiDev")) expected.push("web");
+  if (installedServices.has("sessiond")) expected.push("sessiond");
+  return expected;
+}
+
 export function doctorExitCode(
   generalReadinessOk: boolean,
   nativeServicePlanOk: boolean,
   nodePtyRuntimeOk: boolean,
+  runningComponentsOk: boolean,
 ): 0 | 1 {
-  return generalReadinessOk && nativeServicePlanOk && nodePtyRuntimeOk ? 0 : 1;
+  return generalReadinessOk && nativeServicePlanOk && nodePtyRuntimeOk && runningComponentsOk ? 0 : 1;
 }
 
 async function doctor(): Promise<void> {
@@ -1054,7 +1075,16 @@ async function doctor(): Promise<void> {
     console.log(`- Native user service plan checks skipped on ${platformLabel()}; no native-service drift is reported.`);
   }
   console.log("");
-  await printPiWebVersionReport();
+  const runningVersionInfo = await printPiWebVersionReport();
+  const expectedComponents = expectedRunningComponents(
+    backend === undefined ? new Set<NativeServiceId>() : installedServiceIds(backend),
+    process.env,
+  );
+  const runningComponentsOk = runningComponentsReady(runningVersionInfo, expectedComponents);
+  if (!runningComponentsOk) {
+    console.log("\n✗ Installed PI WEB services are unavailable or stale (see \"Running services\" above).");
+    console.log("  Run `pi-web restart`, then check `pi-web status`.");
+  }
 
   console.log("\nGeneral login-shell readiness (separate from native-service requirements):");
   const generalReadinessOk = runChecks(generalDoctorChecks());
@@ -1101,7 +1131,7 @@ async function doctor(): Promise<void> {
     console.log(`\n${manualRunAdvice()}`);
   }
 
-  if (doctorExitCode(generalReadinessOk, nativeServicePlanOk, nodePtyNativeModuleOk && nodePtySpawnHelperOk) !== 0) process.exitCode = 1;
+  if (doctorExitCode(generalReadinessOk, nativeServicePlanOk, nodePtyNativeModuleOk && nodePtySpawnHelperOk, runningComponentsOk) !== 0) process.exitCode = 1;
 }
 
 function printNodePtyNativeModuleCheck(): boolean {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,7 +8,7 @@ import { fileURLToPath } from "node:url";
 import { defaultPiWebConfigPath, defaultPiWebDataDir, examplePiWebConfig } from "./config.js";
 import { piWebDockerCommand, type PiWebDockerMode } from "./docker/piWebDockerCommandPlan.js";
 import { runPluginRecoveryCli, type SessionDaemonRestartPlan } from "./pluginRecoveryCli.js";
-import { packageVersion, printPiWebVersionReport, runningComponentsReady, type RunningComponentId } from "./piWebVersionReport.js";
+import { packageVersion, printPiWebVersionReport, probeRunningComponentReady, runningComponentsReady, type RunningComponentId } from "./piWebVersionReport.js";
 import { checkNodePtyDarwinSpawnHelper, formatNodePtyDarwinSpawnHelperCheck } from "./server/diagnostics/nodePtySpawnHelper.js";
 import { checkNodePtyNativeModule, formatNodePtyNativeModuleCheck } from "./server/diagnostics/nodePtyNativeModule.js";
 import {
@@ -17,6 +17,21 @@ import {
   type NativeServiceInstallCandidate,
   type NativeServiceInstallFailure,
 } from "./nativeServices/serviceInstall.js";
+import {
+  launchdBootoutArgs,
+  launchdServiceTarget,
+  orderServices,
+  performServiceAction,
+  serviceStartOrder,
+  serviceStopOrder,
+  settleLaunchdServiceUnload,
+  startLaunchdService,
+  type LaunchdServiceContext,
+  type ServiceActionDeps,
+  type ServiceActionInput,
+  type ServiceActionResult,
+  type ServiceLifecycleAction,
+} from "./nativeServices/serviceAction.js";
 import {
   minimumSupportedNodeVersion,
   nativeServiceManagerRefs,
@@ -84,12 +99,6 @@ const serviceRefs: Record<ServiceId, ServiceRef> = {
 };
 
 const productionServiceIds: ServiceId[] = [...productionNativeServiceIds];
-const startServiceOrder: ServiceId[] = ["sessiond", "web", "uiDev"];
-const stopServiceOrder: ServiceId[] = ["web", "uiDev", "sessiond"];
-// Restart web/UI before sessiond: when `pi-web restart` runs in a pi-web
-// terminal (owned by sessiond), restarting sessiond kills the command, so any
-// services handled after it would never be restarted.
-const restartServiceOrder: ServiceId[] = ["web", "uiDev", "sessiond"];
 
 function platformLabel(): string {
   if (process.platform === "darwin") return "macOS";
@@ -283,24 +292,12 @@ function productionServiceRefs(): ServiceRef[] {
   return serviceRefList(productionServiceIds);
 }
 
-function orderServiceRefs(refs: ServiceRef[], order: ServiceId[]): ServiceRef[] {
-  const byId = new Map(refs.map((ref) => [ref.id, ref]));
-  return order.flatMap((id) => {
-    const ref = byId.get(id);
-    return ref === undefined ? [] : [ref];
-  });
-}
-
 function startOrder(refs: ServiceRef[]): ServiceRef[] {
-  return orderServiceRefs(refs, startServiceOrder);
+  return orderServices(refs, serviceStartOrder);
 }
 
 function stopOrder(refs: ServiceRef[]): ServiceRef[] {
-  return orderServiceRefs(refs, stopServiceOrder);
-}
-
-function restartOrder(refs: ServiceRef[]): ServiceRef[] {
-  return orderServiceRefs(refs, restartServiceOrder);
+  return orderServices(refs, serviceStopOrder);
 }
 
 function devRootPath(): string {
@@ -383,26 +380,24 @@ function launchdDomain(): string {
   return `gui/${String(userInfo().uid)}`;
 }
 
-function launchdServiceTarget(ref: ServiceRef): string {
-  return `${launchdDomain()}/${ref.launchdLabel}`;
+function currentLaunchdServiceTarget(ref: ServiceRef): string {
+  return launchdServiceTarget(launchdDomain(), ref);
 }
 
-function launchdIsLoaded(ref: ServiceRef): boolean {
-  return capture("launchctl", ["print", launchdServiceTarget(ref)]).status === 0;
+function launchdActionContext(): LaunchdServiceContext {
+  return { domain: launchdDomain(), plistPath: launchdPlistPath };
 }
 
-function launchdBootout(ref: ServiceRef): void {
-  runQuiet("launchctl", ["bootout", launchdServiceTarget(ref)]);
-}
-
-function launchdBootstrap(ref: ServiceRef): void {
-  run("launchctl", ["bootstrap", launchdDomain(), launchdPlistPath(ref)], { check: true });
-  run("launchctl", ["enable", launchdServiceTarget(ref)], { check: true });
-}
-
-function launchdStart(ref: ServiceRef): void {
-  if (!launchdIsLoaded(ref)) launchdBootstrap(ref);
-  run("launchctl", ["kickstart", launchdServiceTarget(ref)], { check: true });
+function serviceActionDeps(backend: ServiceBackend): ServiceActionDeps {
+  return {
+    run: (command, args) => run(command, args),
+    runQuiet,
+    sleep: (ms) => new Promise<void>((resolve) => {
+      setTimeout(resolve, ms);
+    }),
+    isServiceRunning: (ref) => runtimeStatus(backend, ref).health === "running",
+    isComponentReady: probeRunningComponentReady,
+  };
 }
 
 async function installLaunchdServices(plan: NativeServicePlan): Promise<void> {
@@ -411,7 +406,9 @@ async function installLaunchdServices(plan: NativeServicePlan): Promise<void> {
   await mkdir(launchdServiceDir, { recursive: true });
   await mkdir(logDir, { recursive: true });
 
-  for (const ref of stopOrder(allServiceRefs())) launchdBootout(ref);
+  for (const ref of stopOrder(allServiceRefs())) {
+    runQuiet("launchctl", launchdBootoutArgs(currentLaunchdServiceTarget(ref)));
+  }
 
   for (const ref of allServiceRefs().filter((candidate) => !selected.has(candidate.id))) {
     await rm(launchdPlistPath(ref), { force: true });
@@ -422,7 +419,16 @@ async function installLaunchdServices(plan: NativeServicePlan): Promise<void> {
     await writeFile(plistPath, renderLaunchdPlist(plan, service, logDir));
   }
 
-  for (const service of plan.services) launchdStart(serviceRefFromPlan(service.id, service.manager));
+  // Settle each bootout before deciding bootstrap vs kickstart: acting on a
+  // label launchd is still asynchronously unloading races the teardown and can
+  // lose the service entirely (the same defect the restart path had).
+  const context = launchdActionContext();
+  const deps = serviceActionDeps(plan.backend);
+  for (const service of plan.services) {
+    const ref = serviceRefFromPlan(service.id, service.manager);
+    await settleLaunchdServiceUnload(currentLaunchdServiceTarget(ref), deps);
+    startLaunchdService(ref, context, deps);
+  }
 }
 
 async function installNativeServices(plan: NativeServicePlan): Promise<void> {
@@ -444,7 +450,7 @@ async function uninstallSystemdServices(): Promise<void> {
 
 async function uninstallLaunchdServices(): Promise<void> {
   for (const ref of stopOrder(allServiceRefs())) {
-    launchdBootout(ref);
+    runQuiet("launchctl", launchdBootoutArgs(currentLaunchdServiceTarget(ref)));
     await rm(launchdPlistPath(ref), { force: true });
   }
 }
@@ -534,7 +540,7 @@ export function launchdRuntimeDetails(output: string): { state: string; detail: 
 }
 
 function launchdRuntimeStatus(backend: ServiceBackend, ref: ServiceRef): ServiceRuntimeStatus {
-  const target = launchdServiceTarget(ref);
+  const target = currentLaunchdServiceTarget(ref);
   const filePath = serviceFilePath(backend, ref);
   if (!serviceFileExists(backend, ref)) return makeServiceRuntimeStatus(ref, "not-installed", "not installed", target, filePath);
 
@@ -716,31 +722,7 @@ async function uninstall(): Promise<void> {
   console.log(`PI WEB ${backend.label} removed. Production and development service files were removed; config and data were left in place.`);
 }
 
-function systemdServiceAction(action: "start" | "stop" | "restart", refs: ServiceRef[]): void {
-  const orderedRefs = action === "stop" ? stopOrder(refs) : action === "restart" ? restartOrder(refs) : startOrder(refs);
-  run("systemctl", ["--user", action, ...orderedRefs.map((ref) => ref.systemdName)], { check: true });
-}
-
-function launchdServiceAction(action: "start" | "stop" | "restart", refs: ServiceRef[]): void {
-  if (action === "stop") {
-    for (const ref of stopOrder(refs)) launchdBootout(ref);
-    return;
-  }
-
-  if (action === "restart") {
-    // Restart each service fully (bootout + start) before moving to the next,
-    // so the web/UI services are back up before sessiond is restarted.
-    for (const ref of restartOrder(refs)) {
-      launchdBootout(ref);
-      launchdStart(ref);
-    }
-    return;
-  }
-
-  for (const ref of startOrder(refs)) launchdStart(ref);
-}
-
-function serviceAction(action: "start" | "stop" | "restart" | "status"): void {
+async function serviceAction(action: ServiceLifecycleAction | "status"): Promise<void> {
   const backend = requireServiceBackend(`pi-web ${action}`);
   if (action === "status") {
     if (!printServiceStatusReport(backend)) process.exitCode = 1;
@@ -748,8 +730,16 @@ function serviceAction(action: "start" | "stop" | "restart" | "status"): void {
   }
 
   const refs = installedServiceRefs(backend);
-  if (backend.kind === "systemd") systemdServiceAction(action, refs);
-  else launchdServiceAction(action, refs);
+  const input: ServiceActionInput = { backend, action, refs, launchdContext: launchdActionContext() };
+  const result: ServiceActionResult = await performServiceAction(input, serviceActionDeps(backend));
+  if (result.unreadyServices.length > 0) {
+    for (const ref of result.unreadyServices) {
+      const target = backend.kind === "systemd" ? ref.systemdName : currentLaunchdServiceTarget(ref);
+      console.log(`✗ ${serviceDisplayName(ref)} did not become ready (${target}).`);
+    }
+    console.log("  Check `pi-web status` and `pi-web logs` for details.");
+    process.exitCode = 1;
+  }
 }
 
 export interface SessionDaemonRestartPlanOptions {
@@ -1175,7 +1165,7 @@ async function main(): Promise<void> {
   const [command = "help", ...args] = process.argv.slice(2);
   if (command === "install") await install(args);
   else if (command === "uninstall") await uninstall();
-  else if (command === "start" || command === "stop" || command === "restart" || command === "status") serviceAction(command);
+  else if (command === "start" || command === "stop" || command === "restart" || command === "status") await serviceAction(command);
   else if (command === "logs") logs();
   else if (command === "plugins") runPluginRecoveryCli(args, { restartPlan: (context) => sessionDaemonRestartPlan(context) });
   else if (command === "doctor") await doctor();

--- a/src/nativeServices/serviceAction.test.ts
+++ b/src/nativeServices/serviceAction.test.ts
@@ -1,0 +1,421 @@
+import { describe, expect, it } from "vitest";
+import type { RunningComponentId } from "../piWebVersionReport.js";
+import {
+  awaitServicesReady,
+  launchdBootoutArgs,
+  launchdBootstrapArgs,
+  launchdEnableArgs,
+  launchdKickstartArgs,
+  launchdPrintArgs,
+  launchdServiceTarget,
+  orderServices,
+  performServiceAction,
+  readinessComponentForService,
+  restartLaunchdService,
+  ServiceCommandError,
+  serviceRestartOrder,
+  serviceStartOrder,
+  serviceStopOrder,
+  settleLaunchdServiceUnload,
+  startLaunchdService,
+  systemctlUserActionArgs,
+  type LaunchdServiceContext,
+  type LifecycleServiceRef,
+  type ServiceActionDeps,
+  type ServiceActionTiming,
+} from "./serviceAction.js";
+import { nativeServiceManagerRefs, type NativeServiceBackend, type NativeServiceId } from "./servicePlan.js";
+
+const systemdBackend: NativeServiceBackend = { kind: "systemd", label: "systemd user services" };
+const launchdBackend: NativeServiceBackend = { kind: "launchd", label: "LaunchAgents" };
+
+function ref(id: NativeServiceId): LifecycleServiceRef {
+  return { id, ...nativeServiceManagerRefs[id] };
+}
+
+function allRefs(): LifecycleServiceRef[] {
+  return [ref("sessiond"), ref("web"), ref("uiDev")];
+}
+
+const launchdContext: LaunchdServiceContext = {
+  domain: "gui/501",
+  plistPath: (service) => `/LaunchAgents/${service.launchdPlistName}`,
+};
+
+interface RecordedCall {
+  command: string;
+  args: string[];
+}
+
+interface FakeEnvironmentOptions {
+  runStatus?: (command: string, args: string[]) => number;
+  quietStatus?: (command: string, args: string[]) => number;
+  running?: (service: LifecycleServiceRef) => boolean;
+  ready?: (component: RunningComponentId) => boolean;
+}
+
+interface FakeEnvironment {
+  calls: RecordedCall[];
+  sleeps: number[];
+  probedComponents: RunningComponentId[];
+  deps: ServiceActionDeps;
+}
+
+/** Injected boundary fakes: recorded commands, instant sleeps, scripted probes. */
+function fakeEnvironment(options: FakeEnvironmentOptions = {}): FakeEnvironment {
+  const calls: RecordedCall[] = [];
+  const sleeps: number[] = [];
+  const probedComponents: RunningComponentId[] = [];
+  const deps: ServiceActionDeps = {
+    run: (command, args) => {
+      calls.push({ command, args });
+      return options.runStatus?.(command, args) ?? 0;
+    },
+    runQuiet: (command, args) => {
+      calls.push({ command, args });
+      return options.quietStatus?.(command, args) ?? 0;
+    },
+    sleep: (ms) => {
+      sleeps.push(ms);
+      return Promise.resolve();
+    },
+    isServiceRunning: (service) => options.running?.(service) ?? true,
+    isComponentReady: (component) => {
+      probedComponents.push(component);
+      return Promise.resolve(options.ready?.(component) ?? true);
+    },
+  };
+  return { calls, sleeps, probedComponents, deps };
+}
+
+/** Script `launchctl print` statuses in call order (the last one repeats); every other verb succeeds. */
+function launchdPrintSequence(statuses: readonly number[]): (command: string, args: string[]) => number {
+  let printIndex = 0;
+  return (_command, args) => {
+    if (args[0] !== "print") return 0;
+    const status = statuses[Math.min(printIndex, statuses.length - 1)] ?? 1;
+    printIndex += 1;
+    return status;
+  };
+}
+
+const settleTiming: ServiceActionTiming = { launchdUnloadSettleTimeoutMs: 4, launchdUnloadSettleIntervalMs: 1 };
+const readinessTiming: ServiceActionTiming = { readinessTimeoutMs: 3, readinessIntervalMs: 1 };
+
+describe("service manager argument construction", () => {
+  it("builds the systemctl user action vector", () => {
+    expect(systemctlUserActionArgs("restart", ["pi-web.service", "pi-web-sessiond.service"])).toEqual([
+      "--user",
+      "restart",
+      "pi-web.service",
+      "pi-web-sessiond.service",
+    ]);
+  });
+
+  it("builds exact launchctl vectors", () => {
+    expect(launchdBootoutArgs("gui/501/com.pi-web.web")).toEqual(["bootout", "gui/501/com.pi-web.web"]);
+    expect(launchdPrintArgs("gui/501/com.pi-web.web")).toEqual(["print", "gui/501/com.pi-web.web"]);
+    expect(launchdBootstrapArgs("gui/501", "/LaunchAgents/com.pi-web.web.plist")).toEqual([
+      "bootstrap",
+      "gui/501",
+      "/LaunchAgents/com.pi-web.web.plist",
+    ]);
+    expect(launchdEnableArgs("gui/501/com.pi-web.web")).toEqual(["enable", "gui/501/com.pi-web.web"]);
+    expect(launchdKickstartArgs("gui/501/com.pi-web.web")).toEqual(["kickstart", "gui/501/com.pi-web.web"]);
+  });
+
+  it("targets a service inside the user gui domain", () => {
+    expect(launchdServiceTarget("gui/501", ref("web"))).toBe("gui/501/com.pi-web.web");
+  });
+});
+
+describe("orderServices", () => {
+  it("keeps the deliberate lifecycle orders", () => {
+    expect(serviceStartOrder).toEqual(["sessiond", "web", "uiDev"]);
+    expect(serviceStopOrder).toEqual(["web", "uiDev", "sessiond"]);
+    // Restart handles web/UI before sessiond so a restart issued from a pi-web
+    // terminal (killed by the sessiond restart) has already restarted the rest.
+    expect(serviceRestartOrder).toEqual(["web", "uiDev", "sessiond"]);
+  });
+
+  it("orders present services and drops missing ones", () => {
+    expect(orderServices(allRefs(), serviceRestartOrder).map((service) => service.id)).toEqual(["web", "uiDev", "sessiond"]);
+    expect(orderServices([ref("sessiond"), ref("uiDev")], serviceRestartOrder).map((service) => service.id)).toEqual([
+      "uiDev",
+      "sessiond",
+    ]);
+  });
+});
+
+describe("readinessComponentForService", () => {
+  it("maps API-serving services to the web component and sessiond to itself", () => {
+    expect(readinessComponentForService("web")).toBe("web");
+    expect(readinessComponentForService("uiDev")).toBe("web");
+    expect(readinessComponentForService("sessiond")).toBe("sessiond");
+  });
+});
+
+describe("settleLaunchdServiceUnload", () => {
+  it("settles immediately when the label was never loaded", async () => {
+    const env = fakeEnvironment({ quietStatus: launchdPrintSequence([1]) });
+    const settled = await settleLaunchdServiceUnload("gui/501/com.pi-web.web", env.deps, settleTiming);
+    expect(settled).toBe(true);
+    expect(env.calls.filter((call) => call.args[0] === "print")).toHaveLength(1);
+    expect(env.sleeps).toEqual([]);
+  });
+
+  it("waits until the asynchronous unload completes", async () => {
+    const env = fakeEnvironment({ quietStatus: launchdPrintSequence([0, 0, 1]) });
+    const settled = await settleLaunchdServiceUnload("gui/501/com.pi-web.web", env.deps, settleTiming);
+    expect(settled).toBe(true);
+    expect(env.calls.filter((call) => call.args[0] === "print")).toHaveLength(3);
+    expect(env.sleeps).toEqual([1, 1]);
+  });
+
+  it("times out truthfully when the label never disappears", async () => {
+    const env = fakeEnvironment({ quietStatus: launchdPrintSequence([0]) });
+    const settled = await settleLaunchdServiceUnload("gui/501/com.pi-web.web", env.deps, settleTiming);
+    expect(settled).toBe(false);
+    // Four budgeted polls plus the final check, with a sleep between polls.
+    expect(env.calls.filter((call) => call.args[0] === "print")).toHaveLength(5);
+    expect(env.sleeps).toEqual([1, 1, 1, 1]);
+  });
+});
+
+describe("startLaunchdService", () => {
+  it("bootstraps and enables an unloaded label, then kickstarts", () => {
+    const env = fakeEnvironment({ quietStatus: launchdPrintSequence([1]) });
+    startLaunchdService(ref("web"), launchdContext, env.deps);
+    expect(env.calls).toEqual([
+      { command: "launchctl", args: ["print", "gui/501/com.pi-web.web"] },
+      { command: "launchctl", args: ["bootstrap", "gui/501", "/LaunchAgents/com.pi-web.web.plist"] },
+      { command: "launchctl", args: ["enable", "gui/501/com.pi-web.web"] },
+      { command: "launchctl", args: ["kickstart", "gui/501/com.pi-web.web"] },
+    ]);
+  });
+
+  it("only kickstarts an already-loaded label", () => {
+    const env = fakeEnvironment({ quietStatus: launchdPrintSequence([0]) });
+    startLaunchdService(ref("web"), launchdContext, env.deps);
+    expect(env.calls).toEqual([
+      { command: "launchctl", args: ["print", "gui/501/com.pi-web.web"] },
+      { command: "launchctl", args: ["kickstart", "gui/501/com.pi-web.web"] },
+    ]);
+  });
+
+  it("throws ServiceCommandError and skips kickstart when bootstrap fails", () => {
+    const env = fakeEnvironment({
+      quietStatus: launchdPrintSequence([1]),
+      runStatus: (_command, args) => (args[0] === "bootstrap" ? 36 : 0),
+    });
+    expect(() => {
+      startLaunchdService(ref("web"), launchdContext, env.deps);
+    }).toThrow(ServiceCommandError);
+    expect(env.calls.map((call) => call.args[0])).toEqual(["print", "bootstrap"]);
+  });
+});
+
+describe("restartLaunchdService", () => {
+  it("bootouts, settles, then bootstraps and kickstarts once unloaded", async () => {
+    // Print answers: still loaded right after bootout, unloaded on the second
+    // poll, still unloaded at the post-settle start check.
+    const env = fakeEnvironment({ quietStatus: launchdPrintSequence([0, 1, 1]) });
+    await restartLaunchdService(ref("web"), launchdContext, env.deps, settleTiming);
+    expect(env.calls).toEqual([
+      { command: "launchctl", args: ["bootout", "gui/501/com.pi-web.web"] },
+      { command: "launchctl", args: ["print", "gui/501/com.pi-web.web"] },
+      { command: "launchctl", args: ["print", "gui/501/com.pi-web.web"] },
+      { command: "launchctl", args: ["print", "gui/501/com.pi-web.web"] },
+      { command: "launchctl", args: ["bootstrap", "gui/501", "/LaunchAgents/com.pi-web.web.plist"] },
+      { command: "launchctl", args: ["enable", "gui/501/com.pi-web.web"] },
+      { command: "launchctl", args: ["kickstart", "gui/501/com.pi-web.web"] },
+    ]);
+  });
+
+  it("surfaces kickstart failure when the label never settles", async () => {
+    const env = fakeEnvironment({
+      quietStatus: launchdPrintSequence([0]),
+      runStatus: (_command, args) => (args[0] === "kickstart" ? 1 : 0),
+    });
+    await expect(restartLaunchdService(ref("web"), launchdContext, env.deps, settleTiming)).rejects.toThrow(
+      ServiceCommandError,
+    );
+  });
+});
+
+describe("awaitServicesReady", () => {
+  it("returns immediately without sleeping when everything is already ready", async () => {
+    const env = fakeEnvironment();
+    const unready = await awaitServicesReady(allRefs(), env.deps, readinessTiming);
+    expect(unready).toEqual([]);
+    expect(env.sleeps).toEqual([]);
+    // Probed in the order the refs were passed in.
+    expect(env.probedComponents).toEqual(["sessiond", "web", "web"]);
+  });
+});
+
+describe("performServiceAction", () => {
+  it("restarts systemd units in one manager job ordered web, uiDev, sessiond, with no launchd steps", async () => {
+    const env = fakeEnvironment();
+    const result = await performServiceAction(
+      { backend: systemdBackend, action: "restart", refs: allRefs(), launchdContext },
+      env.deps,
+      readinessTiming,
+    );
+    expect(result.unreadyServices).toEqual([]);
+    expect(env.calls).toEqual([
+      { command: "systemctl", args: ["--user", "restart", "pi-web.service", "pi-web-ui-dev.service", "pi-web-sessiond.service"] },
+    ]);
+    expect(env.probedComponents).toEqual(["web", "web", "sessiond"]);
+  });
+
+  it("starts systemd units in start order", async () => {
+    const env = fakeEnvironment();
+    const result = await performServiceAction(
+      { backend: systemdBackend, action: "start", refs: allRefs(), launchdContext },
+      env.deps,
+      readinessTiming,
+    );
+    expect(result.unreadyServices).toEqual([]);
+    expect(env.calls).toEqual([
+      { command: "systemctl", args: ["--user", "start", "pi-web-sessiond.service", "pi-web.service", "pi-web-ui-dev.service"] },
+    ]);
+  });
+
+  it("stops systemd units in stop order and skips the readiness gate", async () => {
+    const env = fakeEnvironment();
+    const result = await performServiceAction(
+      { backend: systemdBackend, action: "stop", refs: allRefs(), launchdContext },
+      env.deps,
+      readinessTiming,
+    );
+    expect(result.unreadyServices).toEqual([]);
+    expect(env.calls).toEqual([
+      { command: "systemctl", args: ["--user", "stop", "pi-web.service", "pi-web-ui-dev.service", "pi-web-sessiond.service"] },
+    ]);
+    expect(env.probedComponents).toEqual([]);
+  });
+
+  it("throws when the systemctl job fails", async () => {
+    const env = fakeEnvironment({ runStatus: () => 4 });
+    await expect(
+      performServiceAction({ backend: systemdBackend, action: "restart", refs: allRefs(), launchdContext }, env.deps, readinessTiming),
+    ).rejects.toThrow(ServiceCommandError);
+  });
+
+  it("restarts each LaunchAgent fully before the next, in web, uiDev, sessiond order", async () => {
+    // Every label is already unloaded when polled, so each service bootstraps fresh.
+    const env = fakeEnvironment({ quietStatus: launchdPrintSequence([1]) });
+    const result = await performServiceAction(
+      { backend: launchdBackend, action: "restart", refs: allRefs(), launchdContext },
+      env.deps,
+      readinessTiming,
+    );
+    expect(result.unreadyServices).toEqual([]);
+    // Per service: bootout, settle poll, post-settle start check, bootstrap,
+    // enable, kickstart — each service fully restarted before the next.
+    expect(env.calls).toEqual([
+      { command: "launchctl", args: ["bootout", "gui/501/com.pi-web.web"] },
+      { command: "launchctl", args: ["print", "gui/501/com.pi-web.web"] },
+      { command: "launchctl", args: ["print", "gui/501/com.pi-web.web"] },
+      { command: "launchctl", args: ["bootstrap", "gui/501", "/LaunchAgents/com.pi-web.web.plist"] },
+      { command: "launchctl", args: ["enable", "gui/501/com.pi-web.web"] },
+      { command: "launchctl", args: ["kickstart", "gui/501/com.pi-web.web"] },
+      { command: "launchctl", args: ["bootout", "gui/501/com.pi-web.ui-dev"] },
+      { command: "launchctl", args: ["print", "gui/501/com.pi-web.ui-dev"] },
+      { command: "launchctl", args: ["print", "gui/501/com.pi-web.ui-dev"] },
+      { command: "launchctl", args: ["bootstrap", "gui/501", "/LaunchAgents/com.pi-web.ui-dev.plist"] },
+      { command: "launchctl", args: ["enable", "gui/501/com.pi-web.ui-dev"] },
+      { command: "launchctl", args: ["kickstart", "gui/501/com.pi-web.ui-dev"] },
+      { command: "launchctl", args: ["bootout", "gui/501/com.pi-web.sessiond"] },
+      { command: "launchctl", args: ["print", "gui/501/com.pi-web.sessiond"] },
+      { command: "launchctl", args: ["print", "gui/501/com.pi-web.sessiond"] },
+      { command: "launchctl", args: ["bootstrap", "gui/501", "/LaunchAgents/com.pi-web.sessiond.plist"] },
+      { command: "launchctl", args: ["enable", "gui/501/com.pi-web.sessiond"] },
+      { command: "launchctl", args: ["kickstart", "gui/501/com.pi-web.sessiond"] },
+    ]);
+  });
+
+  it("starts LaunchAgents in start order without bootout", async () => {
+    const env = fakeEnvironment({ quietStatus: launchdPrintSequence([0]) });
+    const result = await performServiceAction(
+      { backend: launchdBackend, action: "start", refs: [ref("sessiond"), ref("web")], launchdContext },
+      env.deps,
+      readinessTiming,
+    );
+    expect(result.unreadyServices).toEqual([]);
+    expect(env.calls).toEqual([
+      { command: "launchctl", args: ["print", "gui/501/com.pi-web.sessiond"] },
+      { command: "launchctl", args: ["kickstart", "gui/501/com.pi-web.sessiond"] },
+      { command: "launchctl", args: ["print", "gui/501/com.pi-web.web"] },
+      { command: "launchctl", args: ["kickstart", "gui/501/com.pi-web.web"] },
+    ]);
+  });
+
+  it("stops LaunchAgents in stop order without settle or readiness checks", async () => {
+    const env = fakeEnvironment();
+    const result = await performServiceAction(
+      { backend: launchdBackend, action: "stop", refs: allRefs(), launchdContext },
+      env.deps,
+      readinessTiming,
+    );
+    expect(result.unreadyServices).toEqual([]);
+    expect(env.calls).toEqual([
+      { command: "launchctl", args: ["bootout", "gui/501/com.pi-web.web"] },
+      { command: "launchctl", args: ["bootout", "gui/501/com.pi-web.ui-dev"] },
+      { command: "launchctl", args: ["bootout", "gui/501/com.pi-web.sessiond"] },
+    ]);
+    expect(env.probedComponents).toEqual([]);
+  });
+
+  it("reports a manager-running service whose user-facing endpoint never becomes ready", async () => {
+    const env = fakeEnvironment({ ready: (component) => component !== "web" });
+    const result = await performServiceAction(
+      { backend: systemdBackend, action: "restart", refs: [ref("web"), ref("sessiond")], launchdContext },
+      env.deps,
+      readinessTiming,
+    );
+    expect(result.unreadyServices.map((service) => service.id)).toEqual(["web"]);
+    expect(env.sleeps).toEqual([1, 1, 1]);
+  });
+
+  it("reports a service that never reaches manager-reported running without probing its component", async () => {
+    const env = fakeEnvironment({ running: (service) => service.id !== "sessiond" });
+    const result = await performServiceAction(
+      { backend: systemdBackend, action: "restart", refs: [ref("web"), ref("sessiond")], launchdContext },
+      env.deps,
+      readinessTiming,
+    );
+    expect(result.unreadyServices.map((service) => service.id)).toEqual(["sessiond"]);
+    expect(env.probedComponents).toEqual(["web"]);
+  });
+
+  it("flags a launchd restart whose kickstart succeeded against a label that vanished anyway", async () => {
+    // The issue #151 race: bootout's unload never settles during the wait, the
+    // kickstart against the still-resolving record exits 0, and the label is
+    // gone afterwards. The readiness gate must catch what the old
+    // fire-and-forget path reported as success.
+    const env = fakeEnvironment({
+      quietStatus: launchdPrintSequence([0]),
+      running: () => false,
+    });
+    const result = await performServiceAction(
+      { backend: launchdBackend, action: "restart", refs: [ref("web")], launchdContext },
+      env.deps,
+      { launchdUnloadSettleTimeoutMs: 2, launchdUnloadSettleIntervalMs: 1, readinessTimeoutMs: 3, readinessIntervalMs: 1 },
+    );
+    expect(result.unreadyServices.map((service) => service.id)).toEqual(["web"]);
+    expect(env.calls).toContainEqual({ command: "launchctl", args: ["kickstart", "gui/501/com.pi-web.web"] });
+  });
+
+  it("does nothing when no services are selected", async () => {
+    const env = fakeEnvironment();
+    const result = await performServiceAction(
+      { backend: systemdBackend, action: "restart", refs: [], launchdContext },
+      env.deps,
+      readinessTiming,
+    );
+    expect(result.unreadyServices).toEqual([]);
+    expect(env.calls).toEqual([]);
+  });
+});

--- a/src/nativeServices/serviceAction.ts
+++ b/src/nativeServices/serviceAction.ts
@@ -1,0 +1,259 @@
+import type { RunningComponentId } from "../piWebVersionReport.js";
+import type { NativeServiceBackend, NativeServiceId, NativeServiceManagerRef } from "./servicePlan.js";
+
+/** A service under lifecycle control: its stable id plus its manager-specific unit, label, and log names. */
+export interface LifecycleServiceRef extends NativeServiceManagerRef {
+  id: NativeServiceId;
+}
+
+export type ServiceLifecycleAction = "start" | "stop" | "restart";
+
+export const serviceStartOrder: readonly NativeServiceId[] = ["sessiond", "web", "uiDev"];
+export const serviceStopOrder: readonly NativeServiceId[] = ["web", "uiDev", "sessiond"];
+// Restart web/UI before sessiond: when `pi-web restart` runs in a pi-web
+// terminal (owned by sessiond), restarting sessiond kills the command, so any
+// services handled after it would never be restarted.
+export const serviceRestartOrder: readonly NativeServiceId[] = ["web", "uiDev", "sessiond"];
+
+const LAUNCHD_UNLOAD_SETTLE_TIMEOUT_MS = 10_000;
+const LAUNCHD_UNLOAD_SETTLE_INTERVAL_MS = 250;
+const SERVICE_READINESS_TIMEOUT_MS = 30_000;
+const SERVICE_READINESS_INTERVAL_MS = 1_000;
+
+/** Bounded-wait budgets. Tests inject small values together with an instant sleep. */
+export interface ServiceActionTiming {
+  launchdUnloadSettleTimeoutMs?: number;
+  launchdUnloadSettleIntervalMs?: number;
+  readinessTimeoutMs?: number;
+  readinessIntervalMs?: number;
+}
+
+/**
+ * Effect boundary for lifecycle operations. Command runners only report the
+ * exit status; the orchestrator decides what failure means. Probes and sleep
+ * are injected so tests can script manager state and user-facing readiness
+ * without real processes, services, timers, or network.
+ */
+export interface ServiceActionDeps {
+  /** Run a command with inherited stdio; resolves with its exit status. */
+  run(command: string, args: string[]): number;
+  /** Run a command with captured (discarded) output; resolves with its exit status. */
+  runQuiet(command: string, args: string[]): number;
+  /** Wait between polls. */
+  sleep(ms: number): Promise<void>;
+  /** Manager-reported running state (systemd active / launchd state running). */
+  isServiceRunning(ref: LifecycleServiceRef): boolean;
+  /** User-facing readiness of a running component (web/API version endpoint, session daemon health). */
+  isComponentReady(component: RunningComponentId): Promise<boolean>;
+}
+
+/** launchd-specific locations needed to bootstrap a service. */
+export interface LaunchdServiceContext {
+  domain: string;
+  plistPath(ref: LifecycleServiceRef): string;
+}
+
+/** A service-manager command exited nonzero; carries the exact invocation for diagnosis. */
+export class ServiceCommandError extends Error {
+  readonly command: string;
+  readonly args: readonly string[];
+  readonly status: number;
+
+  constructor(command: string, args: readonly string[], status: number) {
+    super(`\`${command} ${args.join(" ")}\` failed with exit status ${String(status)}.`);
+    this.name = "ServiceCommandError";
+    this.command = command;
+    this.args = args;
+    this.status = status;
+  }
+}
+
+export function systemctlUserActionArgs(action: ServiceLifecycleAction, unitNames: readonly string[]): string[] {
+  return ["--user", action, ...unitNames];
+}
+
+export function launchdBootoutArgs(target: string): string[] {
+  return ["bootout", target];
+}
+
+export function launchdPrintArgs(target: string): string[] {
+  return ["print", target];
+}
+
+export function launchdBootstrapArgs(domain: string, plistPath: string): string[] {
+  return ["bootstrap", domain, plistPath];
+}
+
+export function launchdEnableArgs(target: string): string[] {
+  return ["enable", target];
+}
+
+export function launchdKickstartArgs(target: string): string[] {
+  return ["kickstart", target];
+}
+
+export function launchdServiceTarget(domain: string, ref: LifecycleServiceRef): string {
+  return `${domain}/${ref.launchdLabel}`;
+}
+
+/** Order refs by service id, dropping ids that are not present. */
+export function orderServices<T extends LifecycleServiceRef>(refs: readonly T[], order: readonly NativeServiceId[]): T[] {
+  const byId = new Map(refs.map((ref) => [ref.id, ref]));
+  return order.flatMap((id) => {
+    const ref = byId.get(id);
+    return ref === undefined ? [] : [ref];
+  });
+}
+
+function orderForAction(action: ServiceLifecycleAction): readonly NativeServiceId[] {
+  if (action === "stop") return serviceStopOrder;
+  if (action === "restart") return serviceRestartOrder;
+  return serviceStartOrder;
+}
+
+/**
+ * The running component a service must make responsive: the API-serving
+ * services (production web, development UI/API) back the web component; the
+ * session daemon backs itself.
+ */
+export function readinessComponentForService(id: NativeServiceId): RunningComponentId {
+  return id === "sessiond" ? "sessiond" : "web";
+}
+
+function runChecked(deps: Pick<ServiceActionDeps, "run">, command: string, args: string[]): void {
+  const status = deps.run(command, args);
+  if (status !== 0) throw new ServiceCommandError(command, args, status);
+}
+
+function launchdServiceLoaded(target: string, deps: Pick<ServiceActionDeps, "runQuiet">): boolean {
+  return deps.runQuiet("launchctl", launchdPrintArgs(target)) === 0;
+}
+
+/**
+ * Wait until launchd has fully unloaded a service after bootout. `launchctl
+ * bootout` only requests teardown: the label keeps resolving while launchd
+ * unloads asynchronously, and acting on the still-loaded record races the
+ * unload (a kickstart can succeed against the dying record just before the
+ * label disappears for good). A label that was never loaded settles
+ * immediately. Returns false when the label is still loaded after the
+ * timeout; the caller then falls back to the checked kickstart path, which
+ * keeps the outcome truthful instead of silently losing the service.
+ */
+export async function settleLaunchdServiceUnload(
+  target: string,
+  deps: Pick<ServiceActionDeps, "runQuiet" | "sleep">,
+  timing: ServiceActionTiming = {},
+): Promise<boolean> {
+  const timeoutMs = timing.launchdUnloadSettleTimeoutMs ?? LAUNCHD_UNLOAD_SETTLE_TIMEOUT_MS;
+  const intervalMs = timing.launchdUnloadSettleIntervalMs ?? LAUNCHD_UNLOAD_SETTLE_INTERVAL_MS;
+  const maxPolls = Math.max(1, Math.ceil(timeoutMs / intervalMs));
+  for (let poll = 0; poll < maxPolls; poll += 1) {
+    if (!launchdServiceLoaded(target, deps)) return true;
+    await deps.sleep(intervalMs);
+  }
+  return !launchdServiceLoaded(target, deps);
+}
+
+/**
+ * Start (or kick) one LaunchAgent: bootstrap and enable only when the label
+ * is not loaded, then kickstart. Any manager failure throws ServiceCommandError.
+ */
+export function startLaunchdService(
+  ref: LifecycleServiceRef,
+  context: LaunchdServiceContext,
+  deps: Pick<ServiceActionDeps, "run" | "runQuiet">,
+): void {
+  const target = launchdServiceTarget(context.domain, ref);
+  if (!launchdServiceLoaded(target, deps)) {
+    runChecked(deps, "launchctl", launchdBootstrapArgs(context.domain, context.plistPath(ref)));
+    runChecked(deps, "launchctl", launchdEnableArgs(target));
+  }
+  runChecked(deps, "launchctl", launchdKickstartArgs(target));
+}
+
+/**
+ * Restart one LaunchAgent without racing launchd's asynchronous unload:
+ * bootout, wait for the label to disappear, then start. A settle timeout
+ * falls through to the start path, whose kickstart is checked, so a stuck
+ * unload surfaces as a failure instead of an exit-0-while-gone restart.
+ */
+export async function restartLaunchdService(
+  ref: LifecycleServiceRef,
+  context: LaunchdServiceContext,
+  deps: Pick<ServiceActionDeps, "run" | "runQuiet" | "sleep">,
+  timing: ServiceActionTiming = {},
+): Promise<void> {
+  const target = launchdServiceTarget(context.domain, ref);
+  deps.runQuiet("launchctl", launchdBootoutArgs(target));
+  await settleLaunchdServiceUnload(target, deps, timing);
+  startLaunchdService(ref, context, deps);
+}
+
+/**
+ * Wait until every service is manager-reported running and its user-facing
+ * component responds. Manager state gates the component probe: a service that
+ * is not running yet is not probed. Returns the services still unready when
+ * the bounded wait expires.
+ */
+export async function awaitServicesReady(
+  refs: readonly LifecycleServiceRef[],
+  deps: Pick<ServiceActionDeps, "sleep" | "isServiceRunning" | "isComponentReady">,
+  timing: ServiceActionTiming = {},
+): Promise<LifecycleServiceRef[]> {
+  const timeoutMs = timing.readinessTimeoutMs ?? SERVICE_READINESS_TIMEOUT_MS;
+  const intervalMs = timing.readinessIntervalMs ?? SERVICE_READINESS_INTERVAL_MS;
+  const maxPolls = Math.max(1, Math.ceil(timeoutMs / intervalMs));
+  const pending = new Set(refs);
+  for (let poll = 0; poll < maxPolls && pending.size > 0; poll += 1) {
+    for (const ref of [...pending]) {
+      if (!deps.isServiceRunning(ref)) continue;
+      if (await deps.isComponentReady(readinessComponentForService(ref.id))) pending.delete(ref);
+    }
+    if (pending.size > 0) await deps.sleep(intervalMs);
+  }
+  return [...pending];
+}
+
+export interface ServiceActionInput {
+  backend: NativeServiceBackend;
+  action: ServiceLifecycleAction;
+  refs: readonly LifecycleServiceRef[];
+  launchdContext: LaunchdServiceContext;
+}
+
+export interface ServiceActionResult {
+  /** Services still unready when the bounded wait expired; always empty for `stop`. */
+  unreadyServices: LifecycleServiceRef[];
+}
+
+/**
+ * Perform a start/stop/restart against the native service manager, then — for
+ * start and restart — verify that each affected service actually becomes
+ * ready. systemd restarts are a single synchronous manager job; launchd
+ * restarts settle each asynchronous bootout before the bootstrap-vs-kickstart
+ * decision. The readiness gate is what makes exit-0-while-not-serving
+ * impossible on both backends.
+ */
+export async function performServiceAction(
+  input: ServiceActionInput,
+  deps: ServiceActionDeps,
+  timing: ServiceActionTiming = {},
+): Promise<ServiceActionResult> {
+  const refs = orderServices(input.refs, orderForAction(input.action));
+  if (refs.length === 0) return { unreadyServices: [] };
+
+  if (input.backend.kind === "systemd") {
+    runChecked(deps, "systemctl", systemctlUserActionArgs(input.action, refs.map((ref) => ref.systemdName)));
+  } else if (input.action === "stop") {
+    for (const ref of refs) deps.runQuiet("launchctl", launchdBootoutArgs(launchdServiceTarget(input.launchdContext.domain, ref)));
+  } else if (input.action === "restart") {
+    // Restart each service fully (bootout + settle + start) before moving to
+    // the next, so the web/UI services are back up before sessiond is restarted.
+    for (const ref of refs) await restartLaunchdService(ref, input.launchdContext, deps, timing);
+  } else {
+    for (const ref of refs) startLaunchdService(ref, input.launchdContext, deps);
+  }
+
+  if (input.action === "stop") return { unreadyServices: [] };
+  return { unreadyServices: await awaitServicesReady(refs, deps, timing) };
+}

--- a/src/piWebVersionReport.test.ts
+++ b/src/piWebVersionReport.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { runningComponentsReady, type RunningVersionInfo } from "./piWebVersionReport.js";
+import type { PiWebComponentStatus } from "./shared/apiTypes.js";
+
+function componentStatus(overrides: Partial<PiWebComponentStatus> = {}): PiWebComponentStatus {
+  return {
+    component: "web",
+    label: "Web/UI",
+    available: true,
+    stale: false,
+    ...overrides,
+  };
+}
+
+function sessiondStatus(overrides: Partial<PiWebComponentStatus> = {}): PiWebComponentStatus {
+  return componentStatus({ component: "sessiond", label: "Session daemon", ...overrides });
+}
+
+describe("runningComponentsReady", () => {
+  it("passes when nothing is expected even if components are unavailable", () => {
+    const info: RunningVersionInfo = { webError: "connection refused", sessiondError: "socket missing" };
+
+    expect(runningComponentsReady(info, [])).toBe(true);
+  });
+
+  it("passes when every expected component is available and current", () => {
+    const info: RunningVersionInfo = { web: componentStatus(), sessiond: sessiondStatus() };
+
+    expect(runningComponentsReady(info, ["web", "sessiond"])).toBe(true);
+  });
+
+  it("fails when an expected component is unavailable", () => {
+    const info: RunningVersionInfo = {
+      sessiond: sessiondStatus({ available: false, error: "health probe failed" }),
+    };
+
+    expect(runningComponentsReady(info, ["sessiond"])).toBe(false);
+  });
+
+  it("fails when an expected component is stale (restart needed)", () => {
+    const info: RunningVersionInfo = {
+      web: componentStatus({ stale: true, runtimeVersion: "1.202608.0", installedVersion: "1.202608.1" }),
+    };
+
+    expect(runningComponentsReady(info, ["web"])).toBe(false);
+  });
+
+  it("fails when an expected component is absent from the report (error-only entry)", () => {
+    const info: RunningVersionInfo = { sessiondError: "connect ENOENT /run/pi-web/sessiond.sock" };
+
+    expect(runningComponentsReady(info, ["sessiond"])).toBe(false);
+  });
+
+  it("ignores components that are not expected regardless of their state", () => {
+    const info: RunningVersionInfo = {
+      web: componentStatus({ available: false, error: "down" }),
+      sessiond: sessiondStatus(),
+    };
+
+    expect(runningComponentsReady(info, ["sessiond"])).toBe(true);
+  });
+});

--- a/src/piWebVersionReport.ts
+++ b/src/piWebVersionReport.ts
@@ -42,6 +42,35 @@ export function runningComponentsReady(info: RunningVersionInfo, expected: reado
   });
 }
 
+/**
+ * Readiness probe for service lifecycle waits: the web component is ready when
+ * the web/API version endpoint (or its legacy status fallback) serves a
+ * parseable response; the session daemon is ready when its health endpoint
+ * serves version information. Shares the version report's endpoints and
+ * parsing so lifecycle readiness matches what `pi-web version` reports.
+ */
+export async function probeRunningComponentReady(component: RunningComponentId): Promise<boolean> {
+  if (component === "sessiond") {
+    const sessiond = await collectRunningSessiondInfo();
+    return sessiond.component !== undefined;
+  }
+  const endpoint = webVersionEndpoint();
+  if (endpoint.endpoint === undefined) return false;
+  try {
+    await fetchPiWebVersionResponse(endpoint.endpoint);
+    return true;
+  } catch (error) {
+    const statusEndpoint = statusEndpointFor(endpoint.endpoint);
+    if (!isHttpNotFound(error) || statusEndpoint === endpoint.endpoint) return false;
+    try {
+      await fetchPiWebVersionResponse(statusEndpoint);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}
+
 export function packageVersion(): string {
   return readPackageInfo()?.version ?? DEFAULT_PACKAGE_VERSION;
 }

--- a/src/piWebVersionReport.ts
+++ b/src/piWebVersionReport.ts
@@ -18,7 +18,7 @@ interface PackageInfo {
   path: string;
 }
 
-interface RunningVersionInfo {
+export interface RunningVersionInfo {
   generatedAt?: string;
   web?: PiWebComponentStatus;
   sessiond?: PiWebComponentStatus;
@@ -26,14 +26,32 @@ interface RunningVersionInfo {
   sessiondError?: string;
 }
 
+export type RunningComponentId = PiWebComponentStatus["component"];
+
+/**
+ * Readiness rule for `pi-web doctor`: an expected running component is ready
+ * only when the report carries its status and that status is available and not
+ * stale. A component missing from the report (an error-only entry) is not
+ * ready. Components that are not expected stay informational regardless of
+ * state.
+ */
+export function runningComponentsReady(info: RunningVersionInfo, expected: readonly RunningComponentId[]): boolean {
+  return expected.every((id) => {
+    const status = info[id];
+    return status !== undefined && status.available && !status.stale;
+  });
+}
+
 export function packageVersion(): string {
   return readPackageInfo()?.version ?? DEFAULT_PACKAGE_VERSION;
 }
 
-export async function printPiWebVersionReport(): Promise<void> {
+export async function printPiWebVersionReport(): Promise<RunningVersionInfo> {
   console.log("PI WEB version");
   printInstalledPackageVersions();
-  printRunningVersionInfo(await collectRunningVersionInfo());
+  const runningInfo = await collectRunningVersionInfo();
+  printRunningVersionInfo(runningInfo);
+  return runningInfo;
 }
 
 function packageRootPath(): string {


### PR DESCRIPTION
## Summary

Fixes two macOS service-readiness defects where PI WEB CLI commands reported success while services were not actually running, and extends the same readiness guarantees to the Linux/systemd path (the defects' shared-code-path equivalents), per code inspection.

- **#152 — `pi-web doctor` exits 0 while Session daemon is unavailable.** `printPiWebVersionReport()` returned `void`, so `doctorExitCode()` never saw the running-component availability it had just printed. The report now returns the collected `RunningVersionInfo`, and a pure `runningComponentsReady(info, expected)` rule fails doctor when an **expected** component is absent, unavailable, or stale (restart needed). `expectedRunningComponents(installedServiceIds, env)` defines what is expected: sessiond when its service file is installed, Web/UI when web or uiDev is installed, both under the Docker runtime marker, and nothing on machines with no installed services (preserves the previous informational outcome there). The code path is platform-independent, so the Linux/systemd equivalent and Docker deployments are covered by the same fix.
- **#151 — `pi-web restart` can exit 0 while LaunchAgents disappear.** The launchd restart path ran `launchctl bootout` immediately followed by a bootstrap-vs-kickstart decision, racing launchd's asynchronous unload: a kickstart could succeed against the still-registered dying record just before the label disappeared for good, and the command exited 0 with LaunchAgents gone. Restart (and install, which had the identical race) now settles each bootout with a bounded `launchctl print` poll (10 s) before deciding bootstrap vs kickstart; a settle timeout falls through to the checked kickstart path so a stuck unload surfaces nonzero instead of silently losing the service.
- **New readiness gate on `start`/`restart` (launchd and systemd).** `pi-web start`/`pi-web restart` now wait (bounded, 30 s) for each affected service to be manager-reported running **and** its user-facing component responsive (web/API version endpoint, session daemon health — reusing the version report's probes), exiting nonzero and naming the unready service with a pointer to `pi-web status`/`pi-web logs`. `pi-web stop` keeps its previous fire-and-forget bootout behavior.
- Lifecycle decision logic moved into a testable `src/nativeServices/serviceAction.ts` with injected command/probe/sleep seams and pure `launchctl`/`systemctl` argument construction.

## Behavioral / contract changes

- `pi-web doctor` now exits nonzero when an installed Web/UI or session daemon component is unavailable or stale. Nothing-installed machines are unchanged (informational only).
- `pi-web start` / `pi-web restart` on launchd and systemd now gate on manager-reported running + user-facing responsiveness and exit nonzero naming unready services.
- launchd restart/install settle each bootout before the bootstrap-vs-kickstart decision.
- Hard manager failures (`bootstrap`/`kickstart`/`systemctl` nonzero) now surface as a `ServiceCommandError` → message + exit 1 via main's catch, instead of re-exiting with the child's exit status.

No migration or deployment-ordering considerations: the changes are confined to the CLI's service-lifecycle paths; `src/server/sessiond.ts` and session-daemon-only code are untouched, so no session daemon restart is required to adopt them.

## Verification

On HEAD `b4f68fb044c56a3c7fba9da1096a8125fdd16f3a` (independently re-run by the whole-work reviewer, all exit 0):

- `npm run typecheck`
- `npm run lint`
- `npm test` — 320 files, 2992 passed, 2 skipped (pre-existing skips)
- `npm run knip`
- `npm run build` (only the pre-existing Vite chunk-size warning)

Tests follow the repository testing guide: typed fakes at injected boundaries, exact command-sequence assertions, no real processes/network/timers; includes a regression test scripting the exact issue-#151 bootout/kickstart race.

macOS behavior is verified by unit tests and code inspection only — **no on-hardware macOS verification was performed** (no macOS machine available).

## Known residuals / possible follow-ups (not in scope here)

- `pi-web restart` run from a PI WEB-owned terminal is killed when sessiond teardown completes, so the post-sessiond settle/readiness wait may not run and sessiond may stay down until an external `pi-web start`. Pre-fix that scenario was itself the racy label loss, so this is not a regression; a `kickstart -k` special-case for sessiond is a candidate follow-up.
- Readiness/settle budgets are poll-count budgets, not wall-clock: a wedged accept-but-never-respond endpoint can stretch the nominal 30 s readiness wait (per-probe HTTP timeout per poll). Connection-refused (the common not-ready case) fails fast.

Closes #151
Closes #152
