### PR TITLE
fix(sessions): refresh externally advanced transcripts

### DIFF
--- a/.changeset/refresh-external-session-transcripts.md
+++ b/.changeset/refresh-external-session-transcripts.md
@@ -1,0 +1,5 @@
+---
+"@jmfederico/pi-web": patch
+---
+
+Keep selected sessions current when another Pi process appends to their transcript, without replacing active Pi Web runtimes.

--- a/src/client/src/components/PiWebApp.ts
+++ b/src/client/src/components/PiWebApp.ts
@@ -79,6 +79,7 @@ import { appStyles } from "./shared";
 
 
 const PI_WEB_STATUS_REFRESH_MS = 15 * 60 * 1000;
+const SELECTED_SESSION_REFRESH_MS = 5_000;
 const PI_WEB_STATUS_DEFER_MS = 750;
 const REMOTE_ROUTE_RESTORE_RETRY_DELAYS_MS = [1_000, 3_000, 8_000, 15_000, 30_000] as const;
 const GLOBAL_SHORTCUT_LISTENER_OPTIONS = { capture: true } as const;
@@ -205,6 +206,7 @@ export class PiWebApp extends LitElement {
   private readonly systemLightThemeMedia = typeof window !== "undefined" && "matchMedia" in window ? window.matchMedia("(prefers-color-scheme: light)") : undefined;
   private terminalAutoStartWorkspaceId: string | undefined;
   private piWebStatusTimer: number | undefined;
+  private selectedSessionRefreshTimer: number | undefined;
   private piWebStatusDeferredTimer: number | undefined;
   private workspaceDeletionPollTimer: number | undefined;
   private refreshingWorkspaceDeletionRuns = false;
@@ -335,6 +337,7 @@ export class PiWebApp extends LitElement {
     this.connectRealtime();
     this.syncSessionUnreadMachines();
     this.piWebStatusTimer = window.setInterval(() => { this.schedulePiWebStatusRefresh(); }, PI_WEB_STATUS_REFRESH_MS);
+    this.scheduleSelectedSessionRefresh();
     void this.loadClientConfig();
     void this.ensureGatewayPluginsLoaded();
     void this.loadProjectsAndRestoreRoute().finally(() => { this.schedulePiWebStatusRefresh(); });
@@ -358,6 +361,8 @@ export class PiWebApp extends LitElement {
     this.closeMachineActivitySockets();
     if (this.piWebStatusTimer !== undefined) window.clearInterval(this.piWebStatusTimer);
     this.piWebStatusTimer = undefined;
+    if (this.selectedSessionRefreshTimer !== undefined) window.clearTimeout(this.selectedSessionRefreshTimer);
+    this.selectedSessionRefreshTimer = undefined;
     this.clearScheduledPiWebStatusRefresh();
     if (this.workspaceDeletionPollTimer !== undefined) window.clearInterval(this.workspaceDeletionPollTimer);
     this.workspaceDeletionPollTimer = undefined;
@@ -414,6 +419,23 @@ export class PiWebApp extends LitElement {
       this.refreshCurrentWorkspaceSurface(),
       this.workspaces.refreshSelectedProjectTopology(),
     ]);
+  }
+
+  /** Poll idle external sessions without overlapping work or waking hidden tabs. */
+  private scheduleSelectedSessionRefresh(): void {
+    if (this.selectedSessionRefreshTimer !== undefined) window.clearTimeout(this.selectedSessionRefreshTimer);
+    this.selectedSessionRefreshTimer = window.setTimeout(() => {
+      this.selectedSessionRefreshTimer = undefined;
+      void this.refreshSelectedTranscript().finally(() => { this.scheduleSelectedSessionRefresh(); });
+    }, SELECTED_SESSION_REFRESH_MS);
+  }
+
+  private async refreshSelectedTranscript(): Promise<void> {
+    const session = this.state.selectedSession;
+    const status = this.state.status;
+    if (session === undefined || session.archived === true || document.visibilityState !== "visible") return;
+    if (status?.isStreaming === true || status?.isCompacting === true || status?.isBashRunning === true || (status?.pendingMessageCount ?? 0) > 0) return;
+    await this.sessions.refreshSelectedSession(session.id);
   }
 
   private schedulePiWebStatusRefresh(delayMs = PI_WEB_STATUS_DEFER_MS): void {

--- a/src/client/src/components/PiWebApp.workspaceTopology.test.ts
+++ b/src/client/src/components/PiWebApp.workspaceTopology.test.ts
@@ -10,6 +10,40 @@ afterEach(() => {
 });
 
 describe("PiWebApp workspace topology refresh wiring", () => {
+  it("refreshes a visible idle selected transcript", async () => {
+    const app = createApp();
+    selectSessionForPolling(app);
+    vi.stubGlobal("document", { visibilityState: "visible" });
+    const sessions: unknown = Reflect.get(app, "sessions");
+    if (!hasSelectedSessionRefresh(sessions)) throw new Error("PiWebApp SessionController was unavailable");
+    const refresh = vi.spyOn(sessions, "refreshSelectedSession").mockResolvedValue();
+    const tick: unknown = Reflect.get(app, "refreshSelectedTranscript");
+    if (typeof tick !== "function") throw new Error("Selected transcript refresh was unavailable");
+
+    await tick.call(app);
+
+    expect(refresh).toHaveBeenCalledOnce();
+    expect(refresh).toHaveBeenCalledWith("session-1");
+  });
+
+  it.each([
+    ["hidden document", { visibilityState: "hidden", isStreaming: false }],
+    ["active session", { visibilityState: "visible", isStreaming: true }],
+  ])("does not poll a %s", async (_label: string, options: { visibilityState: string; isStreaming: boolean }) => {
+    const app = createApp();
+    selectSessionForPolling(app, options.isStreaming);
+    vi.stubGlobal("document", { visibilityState: options.visibilityState });
+    const sessions: unknown = Reflect.get(app, "sessions");
+    if (!hasSelectedSessionRefresh(sessions)) throw new Error("PiWebApp SessionController was unavailable");
+    const refresh = vi.spyOn(sessions, "refreshSelectedSession").mockResolvedValue();
+    const tick: unknown = Reflect.get(app, "refreshSelectedTranscript");
+    if (typeof tick !== "function") throw new Error("Selected transcript refresh was unavailable");
+
+    await tick.call(app);
+
+    expect(refresh).not.toHaveBeenCalled();
+  });
+
   it("re-lists the selected project's workspaces on the browser-resume refresh", async () => {
     const app = createApp();
     stubBackgroundRefreshes(app);
@@ -53,6 +87,16 @@ function createApp(): PiWebApp {
   };
   vi.stubGlobal("window", { location: { search: "" }, localStorage: storage });
   return new PiWebApp();
+}
+
+function selectSessionForPolling(app: PiWebApp, isStreaming = false): void {
+  const state: unknown = Reflect.get(app, "state");
+  if (typeof state !== "object" || state === null) throw new Error("PiWebApp state was unavailable");
+  Reflect.set(app, "state", {
+    ...state,
+    selectedSession: { id: "session-1", cwd: "/workspace", archived: false },
+    status: { isStreaming, isCompacting: false, isBashRunning: false, pendingMessageCount: 0 },
+  });
 }
 
 /**
@@ -111,4 +155,8 @@ async function refreshAppData(app: PiWebApp): Promise<void> {
 
 function isRefreshCallback(value: unknown): value is RefreshCallback {
   return typeof value === "function";
+}
+
+function hasSelectedSessionRefresh(value: unknown): value is { refreshSelectedSession(): Promise<void> } {
+  return typeof value === "object" && value !== null && "refreshSelectedSession" in value && typeof value.refreshSelectedSession === "function";
 }

--- a/src/server/sessions/piSessionManagerGateway.test.ts
+++ b/src/server/sessions/piSessionManagerGateway.test.ts
@@ -1,4 +1,4 @@
-import { appendFile, mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { appendFile, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -183,6 +183,23 @@ describe("Pi session manager gateway", () => {
     await appendFile(path, `${message("m2", "assistant", "hi there")}\n${message("m3", "user", "follow-up")}\n`, "utf8");
 
     await expect(gateway.list(cwd)).resolves.toMatchObject([{ id: "memo-session", cwd, messageCount: 3, firstMessage: "hello" }]);
+  });
+
+  it("opens a fresh transcript snapshot after another process appends", async () => {
+    const sharedSessionDir = join(tempDir, "snapshot-sessions");
+    const path = await writeNamedSessionFile(sharedSessionDir, "snapshot.jsonl", { id: "snapshot-session", cwd });
+    const message = (id: string, parentId: string, role: string, text: string) =>
+      JSON.stringify({ type: "message", id, parentId, timestamp: "2026-01-01T00:01:00.000Z", message: { role, content: [{ type: "text", text }] } });
+    await appendFile(path, `${message("m1", "root", "user", "before")}\n`, "utf8");
+    const gateway = createPiSessionManagerGateway(piProfileOptions({ PI_CODING_AGENT_SESSION_DIR: sharedSessionDir }));
+    if (gateway.readBranch === undefined) throw new Error("Expected transcript snapshot reader");
+    const before = await readFile(path);
+
+    await expect(gateway.readBranch(path)).resolves.toHaveLength(1);
+    await expect(readFile(path)).resolves.toEqual(before);
+    await appendFile(path, `${message("m2", "m1", "assistant", "after")}\n`, "utf8");
+
+    await expect(gateway.readBranch(path)).resolves.toHaveLength(2);
   });
 
   it("invalidateSessionFile drops the memo for a header rewritten in place", async () => {

--- a/src/server/sessions/piSessionManagerGateway.ts
+++ b/src/server/sessions/piSessionManagerGateway.ts
@@ -1,11 +1,12 @@
 import type { Dirent } from "node:fs";
-import { readdir } from "node:fs/promises";
+import { readFile, readdir, stat } from "node:fs/promises";
 import { homedir } from "node:os";
 import { basename, dirname, isAbsolute, join, resolve } from "node:path";
 import { SessionManager, SettingsManager } from "@earendil-works/pi-coding-agent";
 import { AGENT_SESSION_DIR_ENV_KEYS } from "../../config.js";
 import { canonicalizeStoredCwd, cwdPathsEqual } from "../workingDirectory.js";
 import { readSessionHeaderSummary, type SessionHeaderReader } from "./sessionFileHeader.js";
+import { tryParseEntry } from "./sessionFileFormat.js";
 import { SessionSummaryScanner } from "./sessionSummaryScanner.js";
 import type { PiSessionListEntry, PiSessionManager, PiSessionManagerGateway, ResolvedSessionFile } from "./piSessionService.js";
 
@@ -78,6 +79,8 @@ class SettingsAwarePiSessionManagerGateway implements PiSessionManagerGateway {
    * in-place rewrites those checks cannot see.
    */
   private readonly summaryScanner = new SessionSummaryScanner();
+  private readonly transcriptBranches = new Map<string, { signature: string; branch: unknown[] }>();
+  private readonly pendingTranscriptBranches = new Map<string, Promise<unknown[]>>();
 
   constructor(private readonly resolver: SessionDirResolver) {}
 
@@ -111,6 +114,23 @@ class SettingsAwarePiSessionManagerGateway implements PiSessionManagerGateway {
     return SessionManager.create(cwd, resolution.sessionDir, options?.parentSession === undefined ? undefined : { parentSession: options.parentSession });
   }
 
+  async readBranch(path: string): Promise<unknown[]> {
+    const file = await stat(path);
+    const signature = `${String(file.dev)}:${String(file.ino)}:${String(file.size)}:${String(file.mtimeMs)}`;
+    const cached = this.transcriptBranches.get(path);
+    if (cached?.signature === signature) return cached.branch;
+    const pending = this.pendingTranscriptBranches.get(path);
+    if (pending !== undefined) return pending;
+    const read = readTranscriptBranch(path)
+      .then((branch) => {
+        this.transcriptBranches.set(path, { signature, branch });
+        return branch;
+      })
+      .finally(() => { this.pendingTranscriptBranches.delete(path); });
+    this.pendingTranscriptBranches.set(path, read);
+    return read;
+  }
+
   async listAll(): Promise<PiSessionListEntry[]> {
     const envSessionDir = this.resolver.globalEnvSessionDir();
     const [defaultSessions, envSessions] = await Promise.all([
@@ -123,6 +143,33 @@ class SettingsAwarePiSessionManagerGateway implements PiSessionManagerGateway {
   open(path: string): PiSessionManager {
     return SessionManager.open(path, dirname(path));
   }
+}
+
+/** SDK-compatible active-branch projection with no migration or write side effects. */
+async function readTranscriptBranch(path: string): Promise<unknown[]> {
+  const entries = (await readFile(path, "utf8"))
+    .split("\n")
+    .map(tryParseEntry)
+    .filter((entry): entry is Record<string, unknown> => entry !== undefined && entry["type"] !== "session");
+  const byId = new Map<string, Record<string, unknown>>();
+  let leafId: string | undefined;
+  for (const entry of entries) {
+    const id = entry["id"];
+    if (typeof id !== "string") continue;
+    byId.set(id, entry);
+    leafId = id;
+  }
+  const branch: Record<string, unknown>[] = [];
+  const visited = new Set<string>();
+  let currentId = leafId;
+  while (currentId !== undefined && !visited.has(currentId)) {
+    visited.add(currentId);
+    const entry = byId.get(currentId);
+    if (entry === undefined) break;
+    branch.push(entry);
+    currentId = typeof entry["parentId"] === "string" ? entry["parentId"] : undefined;
+  }
+  return branch.reverse();
 }
 
 export async function listSessionsInDir(sessionDir: string): Promise<PiSessionListEntry[]> {

--- a/src/server/sessions/piSessionService.lifecycle.test.ts
+++ b/src/server/sessions/piSessionService.lifecycle.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os";
 import { join, resolve, sep } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { createPiSessionManagerGateway } from "./piSessionManagerGateway.js";
-import { PiSessionService, type PiAgentSession, type PiSessionRuntime } from "./piSessionService.js";
+import { PiSessionService, type PiAgentSession, type PiSessionRuntime, type ResolvedSessionFile } from "./piSessionService.js";
 import { SessionNotificationStore } from "./sessionNotificationStore.js";
 import { CapturingSessionEventHub, emptyArchiveStore, fakeRuntime, fakeSessionManager, runtimeCreator, sessionGateway, sessionRecord, sessionRef, testModelRuntime, type RuntimeCreator, type SessionGateway } from "./piSessionService.testSupport.js";
 
@@ -181,6 +181,154 @@ describe("PiSessionService lifecycle, listing, and reload", () => {
     expect(loserSubscribe).not.toHaveBeenCalled();
     expect(loserUnsubscribe).not.toHaveBeenCalled();
     expect(loser.calls.dispose).toBe(0);
+  });
+
+  it("reads externally appended transcript entries without replacing or aborting the idle runtime", async () => {
+    const sessionId = "externally-growing-session";
+    const staleBranch = [{ type: "message", message: { role: "user", content: "before" } }];
+    let diskBranch = [...staleBranch];
+    const runtimeManager = fakeSessionManager("/workspace", {
+      getSessionId: () => sessionId,
+      getSessionFile: () => `/sessions/${sessionId}.jsonl`,
+      getBranch: () => staleBranch,
+    });
+    const fake = fakeRuntime(sessionId, { sessionFile: `/sessions/${sessionId}.jsonl`, sessionManager: runtimeManager });
+    const open = vi.fn(() => fakeSessionManager("/workspace", {
+      getSessionId: () => sessionId,
+      getSessionFile: () => `/sessions/${sessionId}.jsonl`,
+      getBranch: () => diskBranch,
+    }));
+    const gateway: SessionGateway = {
+      create: () => fakeSessionManager(),
+      list: () => Promise.resolve([sessionRecord(sessionId)]),
+      listAll: () => Promise.resolve([sessionRecord(sessionId)]),
+      invalidateSessionFile: () => undefined,
+      resolveSessionFile: () => Promise.resolve({ id: sessionId, cwd: "/workspace", path: `/sessions/${sessionId}.jsonl` }),
+      readBranch: () => Promise.resolve(open().getBranch()),
+      open,
+    };
+    const service = new PiSessionService(new CapturingSessionEventHub(), {
+      agentDir: TEST_AGENT_DIR,
+      modelRuntime: testModelRuntime,
+      archiveStore: emptyArchiveStore(),
+      createAgentRuntime: runtimeCreator(fake.runtime),
+      sessionManager: gateway,
+      heartbeatIntervalMs: 60_000,
+    });
+
+    await expect(service.messages(sessionRef(sessionId))).resolves.toMatchObject({
+      messages: [{ role: "user", content: "before" }],
+      total: 1,
+    });
+    diskBranch = [
+      ...staleBranch,
+      { type: "message", message: { role: "assistant", content: "after" } },
+    ];
+
+    await expect(service.messages(sessionRef(sessionId))).resolves.toMatchObject({
+      messages: [{ role: "user", content: "before" }, { role: "assistant", content: "after" }],
+      total: 2,
+    });
+    expect(fake.calls.abort).toBe(0);
+    expect(fake.calls.dispose).toBe(0);
+    expect(service.activeCount()).toBe(1);
+
+    await service.dispose();
+  });
+
+  it("keeps the live runtime authoritative when work starts during disk resolution", async () => {
+    const sessionId = "becomes-active-session";
+    let streaming = false;
+    let finishResolve: ((match: ResolvedSessionFile) => void) | undefined;
+    const resolved = new Promise<ResolvedSessionFile>((resolve) => { finishResolve = resolve; });
+    const runtimeBranch = [{ type: "message", message: { role: "user", content: "live runtime" } }];
+    const fake = fakeRuntime(sessionId, {
+      sessionFile: undefined,
+      sessionManager: fakeSessionManager("/workspace", {
+        getSessionId: () => sessionId,
+        getSessionFile: () => undefined,
+        getBranch: () => runtimeBranch,
+      }),
+    });
+    Object.defineProperty(fake.session, "isStreaming", { get: () => streaming });
+    const readBranch = vi.fn(() => Promise.resolve([{ type: "message", message: { role: "user", content: "external disk" } }]));
+    const gateway: SessionGateway = {
+      create: () => fakeSessionManager(),
+      list: () => Promise.resolve([sessionRecord(sessionId)]),
+      listAll: () => Promise.resolve([sessionRecord(sessionId)]),
+      invalidateSessionFile: () => undefined,
+      resolveSessionFile: () => resolved,
+      readBranch,
+      open: () => fake.session.sessionManager,
+    };
+    const service = new PiSessionService(new CapturingSessionEventHub(), {
+      agentDir: TEST_AGENT_DIR,
+      modelRuntime: testModelRuntime,
+      archiveStore: emptyArchiveStore(),
+      createAgentRuntime: runtimeCreator(fake.runtime),
+      sessionManager: gateway,
+      heartbeatIntervalMs: 60_000,
+    });
+
+    const messages = service.messages(sessionRef(sessionId));
+    await vi.waitFor(() => { expect(finishResolve).toBeTypeOf("function"); });
+    streaming = true;
+    finishResolve?.({ id: sessionId, cwd: "/workspace", path: `/sessions/${sessionId}.jsonl` });
+
+    await expect(messages).resolves.toMatchObject({
+      messages: [{ role: "user", content: "live runtime" }],
+      total: 1,
+    });
+    expect(readBranch).not.toHaveBeenCalled();
+    expect(fake.calls.abort).toBe(0);
+    expect(fake.calls.dispose).toBe(0);
+
+    await service.dispose();
+  });
+
+  it("keeps reading the live runtime while it reports active work", async () => {
+    const sessionId = "active-growing-session";
+    const runtimeBranch = [{ type: "message", message: { role: "user", content: "live runtime" } }];
+    const fake = fakeRuntime(sessionId, {
+      isStreaming: true,
+      sessionFile: `/sessions/${sessionId}.jsonl`,
+      sessionManager: fakeSessionManager("/workspace", {
+        getSessionId: () => sessionId,
+        getSessionFile: () => `/sessions/${sessionId}.jsonl`,
+        getBranch: () => runtimeBranch,
+      }),
+    });
+    const open = vi.fn(() => fakeSessionManager("/workspace", {
+      getSessionId: () => sessionId,
+      getBranch: () => [{ type: "message", message: { role: "user", content: "external disk" } }],
+    }));
+    const gateway: SessionGateway = {
+      create: () => fakeSessionManager(),
+      list: () => Promise.resolve([sessionRecord(sessionId)]),
+      listAll: () => Promise.resolve([sessionRecord(sessionId)]),
+      invalidateSessionFile: () => undefined,
+      resolveSessionFile: () => Promise.resolve({ id: sessionId, cwd: "/workspace", path: `/sessions/${sessionId}.jsonl` }),
+      readBranch: () => Promise.resolve(open().getBranch()),
+      open,
+    };
+    const service = new PiSessionService(new CapturingSessionEventHub(), {
+      agentDir: TEST_AGENT_DIR,
+      modelRuntime: testModelRuntime,
+      archiveStore: emptyArchiveStore(),
+      createAgentRuntime: runtimeCreator(fake.runtime),
+      sessionManager: gateway,
+      heartbeatIntervalMs: 60_000,
+    });
+
+    await expect(service.messages(sessionRef(sessionId))).resolves.toMatchObject({
+      messages: [{ role: "user", content: "live runtime" }],
+      total: 1,
+    });
+    expect(open).toHaveBeenCalledOnce();
+    expect(fake.calls.abort).toBe(0);
+    expect(fake.calls.dispose).toBe(0);
+
+    await service.dispose();
   });
 
   /**

--- a/src/server/sessions/piSessionService.ts
+++ b/src/server/sessions/piSessionService.ts
@@ -352,6 +352,8 @@ export interface PiSessionManagerGateway {
    * told explicitly.
    */
   invalidateSessionFile(sessionFile: string): void;
+  /** Read the active transcript branch without creating a runtime or writing the file. */
+  readBranch?(path: string): Promise<unknown[]>;
   create(cwd: string, options?: { parentSession?: string }): PiSessionManager;
   /**
    * Cross-project listing of Pi's session stores (the default store plus any
@@ -1871,11 +1873,14 @@ export class PiSessionService implements SessionRouteService {
 
   async messages(ref: PiSessionRef, page?: { before?: number; limit?: number }): Promise<ClientMessagePage> {
     const session = await this.getOrOpen(ref);
-    return pageMessagesAtSafeBoundary(historyMessages(session), page);
+    return pageMessagesAtSafeBoundary(historyMessagesFromEntries(await this.readableSessionBranch(ref, session)), page);
   }
 
   async status(ref: PiSessionRef): Promise<ClientSessionStatus> {
-    return this.statusFromSession(await this.sessionForStatusOrDialogClose(ref));
+    const session = await this.sessionForStatusOrDialogClose(ref);
+    if (this.hasActiveWork(session)) return this.statusFromSession(session);
+    const branch = await this.readableSessionBranch(ref, session);
+    return this.statusFromSession(session, transcriptMessageCount(branch));
   }
 
   /**
@@ -2738,6 +2743,25 @@ export class PiSessionService implements SessionRouteService {
 
   private async getOrOpen(ref: PiSessionRef): Promise<PiAgentSession> {
     return (await this.getActive(ref)).runtime.session;
+  }
+
+  /**
+   * An idle runtime is only Pi Web's cached control view. Another Pi process may
+   * keep appending to the same JSONL file, so transcript reads must open a fresh
+   * read-only snapshot rather than serving that cached branch forever. Active
+   * runtimes remain authoritative and are never replaced, reloaded, or aborted.
+   */
+  private async readableSessionBranch(ref: PiSessionRef, session: PiAgentSession): Promise<unknown[]> {
+    if (this.hasActiveWork(session) || this.sessionManager.readBranch === undefined) return session.sessionManager.getBranch();
+    const sessionFile = session.sessionFile ?? session.sessionManager.getSessionFile();
+    const match = sessionFile === undefined ? await this.sessionManager.resolveSessionFile(ref.cwd, ref.id) : undefined;
+    if (this.hasActiveWork(session)) return session.sessionManager.getBranch();
+    const path = sessionFile ?? match?.path;
+    if (path === undefined) return session.sessionManager.getBranch();
+    const snapshot = await this.sessionManager.readBranch(path);
+    // Reading also yields. A prompt that started meanwhile must still win over
+    // the completed disk snapshot and its potentially older event watermark.
+    return this.hasActiveWork(session) ? session.sessionManager.getBranch() : snapshot;
   }
 
   private async getActive(ref: PiSessionRef, options: Pick<CreateSessionRuntimeOptions, "notificationGeneration"> = {}): Promise<ActiveSession<PiSessionRuntime>> {
@@ -3612,7 +3636,7 @@ export class PiSessionService implements SessionRouteService {
     this.events.publishGlobal({ type: "activity.update", activity });
   }
 
-  private statusFromSession(session: PiAgentSession): ClientSessionStatus {
+  private statusFromSession(session: PiAgentSession, messageCount = session.messages.length): ClientSessionStatus {
     const stats = session.getSessionStats();
     const model = session.model === undefined ? undefined : modelToClientModel(session.model);
     const contextUsage = session.getContextUsage();
@@ -3629,7 +3653,7 @@ export class PiSessionService implements SessionRouteService {
       isBashRunning: session.isBashRunning,
       pendingMessageCount: this.pendingMessageCount(session),
       queuedMessages: queuedMessagesFromSession(session, this.compactionQueuedMessages(session.sessionId)),
-      messageCount: session.messages.length,
+      messageCount,
       tokens: stats.tokens,
       cost: stats.cost,
       ...(contextUsage === undefined ? {} : { contextUsage }),
@@ -4128,11 +4152,15 @@ function annotateAssistantThinkingLevel(message: unknown, thinkingLevel: string 
 }
 
 function historyMessages(session: PiAgentSession): unknown[] {
+  return historyMessagesFromEntries(session.sessionManager.getBranch());
+}
+
+function historyMessagesFromEntries(entries: readonly unknown[]): unknown[] {
   const messages: unknown[] = [];
   // Pi records the initial level at session creation and every later change, so
   // walking the branch yields the level in effect for each assistant message.
   let thinkingLevel: string | undefined;
-  for (const entry of session.sessionManager.getBranch()) {
+  for (const entry of entries) {
     if (!isRecord(entry)) continue;
     if (entry["type"] === "message") messages.push(annotateAssistantThinkingLevel(entry["message"], thinkingLevel));
     else if (entry["type"] === "thinking_level_change") {
@@ -4144,6 +4172,14 @@ function historyMessages(session: PiAgentSession): unknown[] {
     else if (entry["type"] === "branch_summary") messages.push({ role: "system", source: "branch_summary", content: `Branch summary:\n\n${stringValue(entry["summary"])}` });
   }
   return messages;
+}
+
+function transcriptMessageCount(entries: readonly unknown[]): number {
+  let count = 0;
+  for (const entry of entries) {
+    if (isRecord(entry) && entry["type"] === "message") count += 1;
+  }
+  return count;
 }
 
 /** custom entry type used to persist parent -> child subsession links outside LLM context. */


### PR DESCRIPTION
## Problem

Pi Web keeps an in-memory `SessionManager` for an opened session. If another Pi process continues that session, the workspace listing sees the appended JSONL entries but the selected-session endpoints still read the cached branch.

That produces a visible rollback: selecting a session can briefly show the current message count from the listing, then replace it with the older runtime count. The open chat does not advance afterward. The manual Reload action from #24 recovers the session, but it requires closing and reopening Pi Web's runtime.

## Change

- Read idle transcript history from a fresh, write-free JSONL branch snapshot.
- Keep Pi Web's live runtime authoritative whenever it has active work, including work that starts while the snapshot path is being resolved.
- Cache snapshots by file identity, size, and mtime so unchanged polling does not reparse the transcript.
- Refresh visible, selected, idle sessions on a completion-scheduled five-second poll so externally appended turns appear without overlap or background-tab work.

The snapshot path does not call `SessionManager.open()`, reload the runtime, or abort/dispose session work.

## Tests

- externally appended entries replace the stale idle view;
- active runtimes never use the disk snapshot;
- work starting during resolution wins the race;
- a real JSONL file is reread after append;
- focused Vitest: 78 passed;
- typecheck, ESLint, Knip, and production build passed.
