### PR TITLE
Add a Nix flake + home-manager module for declarative pi-web deployment

### DIFF
--- a/.changeset/pi-web-nix-flake.md
+++ b/.changeset/pi-web-nix-flake.md
@@ -1,0 +1,5 @@
+---
+"@jmfederico/pi-web": minor
+---
+
+Add a self-contained Nix flake (`flake.nix`) that builds pi-web as a pure package (`nix build .#default`) and ships a home-manager module (`services.pi-web`) that declaratively defines the two systemd user services — the session daemon and the web/API server. Also restores the missing `integrity` hashes on the six nested `@earendil-works/*` entries in `package-lock.json` (an npm lockfile omission) so the lockfile is compatible with nixpkgs' npm tooling. `package.json` is unchanged.

--- a/README.md
+++ b/README.md
@@ -71,6 +71,27 @@ configuration, and operational details in docs/, then link from here. -->
 
 For more install options, including one-line install, Pi package install, WSL/manual usage, and remote access, see the [installation guide](https://pi-web.dev/install).
 
+## Nix
+
+This fork ships a Nix flake that builds pi-web as a pure package and wraps it in a home-manager module for declarative deployment:
+
+```bash
+nix build .#default          # built package: bin/pi-web, bin/pi-web-server, bin/pi-web-sessiond
+nix run .#default -- --help
+```
+
+Consume from another flake:
+
+```nix
+inputs.pi-web.url = "github:jmfederico/pi-web";
+
+home-manager.lib.homeManagerConfiguration {
+  modules = [ inputs.pi-web.homeManagerModules.default { services.pi-web.enable = true; } ];
+}
+```
+
+Available options: `services.pi-web.enable`, `package`, `host`, `port`, `agentDir` (`PI_CODING_AGENT_DIR`, defaults to `~/.pi/agent`), `extraEnvironment`. Two systemd user units are generated (`pi-web-sessiond`, `pi-web`).
+
 ## Core model
 
 PI WEB organizes work like this:

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1787360063,
+        "narHash": "sha256-dt4WdcvsA8/RCe+VZZwqU0X+XMM3wBbGCWA0/sFWzGo=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "2c423e03bbafcff28bfadc6781a4a8257f205cb5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,126 @@
+{
+  description = "pi-web — web UI for the Pi Coding Agent";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  outputs =
+    { self, nixpkgs }:
+    let
+      system = "x86_64-linux";
+      pkgs = nixpkgs.legacyPackages.${system};
+      # Derive version from package.json so it stays in sync with upstream.
+      version = (builtins.fromJSON (builtins.readFile ./package.json)).version;
+      package = pkgs.buildNpmPackage {
+        pname = "pi-web";
+        inherit version;
+        src = self;
+        npmDepsHash = "sha256-ow1Tq1ZFNISShzBRiqYOQqtiqaJ0YnfNO/qo1U0qK7c=";
+        npmDepsFetcherVersion = 2; # v1 cache-key mismatch on nested dev deps (ENOTCACHED)
+        # Upstream supplies the pi SDK as peerDependencies (consumer-installed,
+        # e.g. Docker uses --include=peer). buildNpmPackage does NOT auto-install
+        # peers, so mirror Docker's --include=peer to bring the SDK in at build.
+        npmInstallFlags = [ "--include=peer" ];
+        # npmInstallHook runs `npm prune --omit=dev`, which drops the peer-
+        # installed pi SDK (a devDep in upstream's package.json). Keep the tree
+        # so the runtime server has the SDK.
+        dontNpmPrune = true;
+        nativeBuildInputs = [ pkgs.python3 ]; # node-pty node-gyp build
+        npmBuildScript = "build"; # npm run clean && tsc && build:plugin-api && build:plugins && vite build
+        meta = {
+          description = "Web UI for Pi Coding Agent";
+          homepage = "https://pi-web.dev/";
+          license = pkgs.lib.licenses.mit;
+          mainProgram = "pi-web";
+        };
+      };
+
+      # Home-manager module: defines the two systemd user services (session
+      # daemon + web/API) declaratively. Consume with:
+      #   modules = [ inputs.pi-web.homeManagerModules.default
+      #               { services.pi-web.enable = true; } ];
+      homeManagerModule =
+        { config, lib, ... }:
+        let
+          cfg = config.services.pi-web;
+          serviceEnvironment =
+            [ "PI_WEB_HOST=${cfg.host}" "PI_WEB_PORT=${toString cfg.port}" ]
+            ++ lib.optional (cfg.agentDir != null) "PI_CODING_AGENT_DIR=${cfg.agentDir}"
+            ++ lib.mapAttrsToList (name: value: "${name}=${value}") cfg.extraEnvironment;
+        in
+        {
+          options.services.pi-web = {
+            enable = lib.mkEnableOption "pi-web, a web UI for Pi Coding Agent sessions";
+
+            package = lib.mkOption {
+              type = lib.types.package;
+              default = package;
+              defaultText = lib.literalExpression "the pi-web package built by this flake";
+              description = "The pi-web package to run.";
+            };
+
+            host = lib.mkOption {
+              type = lib.types.str;
+              default = "0.0.0.0";
+              description = "Address the PI WEB server binds (PI_WEB_HOST).";
+            };
+
+            port = lib.mkOption {
+              type = lib.types.port;
+              default = 8504;
+              description = "Port the PI WEB server listens on (PI_WEB_PORT).";
+            };
+
+            agentDir = lib.mkOption {
+              type = lib.types.nullOr lib.types.str;
+              default = null;
+              description = ''
+                Pi coding agent state directory (PI_CODING_AGENT_DIR).
+                Defaults to the pi SDK default `~/.pi/agent` — the state shared with a
+                machine-wide pi install (auth, settings, project trust).
+              '';
+            };
+
+            extraEnvironment = lib.mkOption {
+              type = lib.types.attrsOf lib.types.str;
+              default = { };
+              description = "Additional environment variables for both services.";
+            };
+          };
+
+          config = lib.mkIf cfg.enable {
+            home.packages = [ cfg.package ]; # `pi-web` CLI (status/logs/doctor) on the user's PATH
+
+            systemd.user.services.pi-web-sessiond = {
+              Unit = {
+                Description = "PI WEB session daemon";
+                After = [ "network.target" ];
+              };
+              Service = {
+                Type = "simple";
+                Restart = "on-failure";
+                ExecStart = "${cfg.package}/bin/pi-web-sessiond";
+                Environment = serviceEnvironment;
+              };
+              Install = { WantedBy = [ "default.target" ]; };
+            };
+
+            systemd.user.services.pi-web = {
+              Unit = {
+                Description = "PI WEB server (web UI and API)";
+                After = [ "network.target" "pi-web-sessiond.service" ];
+                Wants = [ "pi-web-sessiond.service" ];
+              };
+              Service = {
+                Type = "simple";
+                Restart = "on-failure";
+                ExecStart = "${cfg.package}/bin/pi-web-server";
+                Environment = serviceEnvironment;
+              };
+              Install = { WantedBy = [ "default.target" ]; };
+            };
+          };
+        };
+    in
+    {
+      packages.${system}.default = package;
+      homeManagerModules.default = homeManagerModule;
+    };
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1545,6 +1545,7 @@
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
       "version": "0.84.1",
       "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.84.1.tgz",
+      "integrity": "sha512-evyzXYWCLQGmcaBYHlmSku02r8qoN4SGI60GZABo6iV+H+nqX+P9ud8fEZ4GmRq9mUSREvvfX+w9dA9ThF9C6w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1562,6 +1563,7 @@
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
       "version": "0.84.1",
       "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.84.1.tgz",
+      "integrity": "sha512-wMsAdJMxuNri08vLqTyYVI201DQQezGhPSTkzYsHdw5dYX3rCNwEmSvpaAwhi7ELKI/2tE/CEgSWg/6iRxSgdQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1588,6 +1590,7 @@
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-client": {
       "version": "0.84.1",
       "resolved": "https://registry.npmjs.org/@earendil-works/pi-client/-/pi-client-0.84.1.tgz",
+      "integrity": "sha512-/V5hGHE4Zq+jG0GtwIB9PyBUOGd6gBLZ7lkQYFKchKnxYHeH3rmWC5xw4kpnZKKBuBuFTdLVbU9vEjlAGMMb2A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1600,6 +1603,7 @@
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-protocol": {
       "version": "0.84.1",
       "resolved": "https://registry.npmjs.org/@earendil-works/pi-protocol/-/pi-protocol-0.84.1.tgz",
+      "integrity": "sha512-Ox1pciyeSPGEEUcxvR0/dJcrY7C6hrEGA8y71rOsvSIUlXN1Cbp/be/eoL71OGDBk5O97TeQPfWN6Ju/2Ehjww==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1612,6 +1616,7 @@
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-telemetry": {
       "version": "0.84.1",
       "resolved": "https://registry.npmjs.org/@earendil-works/pi-telemetry/-/pi-telemetry-0.84.1.tgz",
+      "integrity": "sha512-180/xGJtsq7IoR3p9EKWjRd0e9M4DkxInhlo9xyD7prDC7Qrhqq+nhvwrW0lFjPfXcEI2FSHmGCSyvSJE9GsaQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1621,6 +1626,7 @@
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
       "version": "0.84.1",
       "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.84.1.tgz",
+      "integrity": "sha512-udeXFbgEhJ6JiB0uguwNVNkDy2FENfmtQwPcY+/iJ8GWeq18wkal1tKqa5YyeH0IqtX1vG0cGh8zfSYzyzVuLA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
# Add a Nix flake + home-manager module for declarative pi-web deployment

Refs: #180 (proposal issue — direction confirmed)

## Summary

Adds a self-contained Nix flake that builds pi-web as a pure package and ships a home-manager module defining the two user services. Also restores six missing `integrity` hashes in `package-lock.json` (an npm lockfile omission). `package.json` is **unchanged**.

## What's included

- **`flake.nix`** — single self-contained file: `buildNpmPackage` build producing `bin/pi-web`, `bin/pi-web-server`, `bin/pi-web-sessiond` (node-pty compiled, pi SDK provided via the **peer** mechanism `--include=peer`, mirroring the Dockerfile) **plus** the inline `homeManagerModules.default` below.
- **`homeManagerModules.default`** (inline in the flake) — `services.pi-web` options (`enable`, `package`, `host`, `port`, `agentDir`, `extraEnvironment`) that define the `pi-web-sessiond` + `pi-web` systemd **user** units, matching the split-deployment model in `AGENTS.md`.
- **`flake.lock`** — pins `nixpkgs` to a stable revision.
- **`package-lock.json`** — adds the 6 missing `integrity` hashes on nested `@earendil-works/*` entries (the npm bug; values match the registry). No version or tree changes.
- **`README.md`** — documents `nix build`, `nix run`, and the home-manager consume snippet.
- **`.changeset/pi-web-nix-flake.md`** — `minor` changeset.

## Why peer-based packaging

Upstream supplies the pi SDK as a `peerDependency` so the consumer's install provides it. The build mirrors that (`--include=peer` + `dontNpmPrune` so the peer SDK survives as a runtime dependency). This keeps `package.json` exactly as the project intends — no reclassification, no vendoring.

## Verification performed

- `nix build .#default` succeeds (pure, no `__noChroot`).
- Built package contains the peer pi SDK (`@earendil-works/pi-coding-agent`) and compiled `node-pty`.
- `pi-web-server` boots and serves `HTTP 200`.
- Home-manager configuration eval renders both `pi-web` + `pi-web-sessiond` services pointing at the built binaries.
- Repo pre-commit hook (`npm run verify:staged` → typecheck + knip) passes.

## Not in scope

- No `src/` changes, no service/session semantics changes.
- No change to `package.json` dependency classification.

## Tests

No runtime code changed; verified via the Nix build + boot smoke test and the repo's existing pre-commit (typecheck/knip). Happy to add a CI step for `nix build` if the maintainers want it.
