### PR TITLE
feat(plugins): let plugins select a project from the runtime context

### DIFF
--- a/.changeset/plugin-select-project.md
+++ b/.changeset/plugin-select-project.md
@@ -1,0 +1,5 @@
+---
+"@jmfederico/pi-web": minor
+---
+
+Let browser plugins select a project through the runtime context. `selectProject(projectId, { workspaceId })` routes through the same navigation seam as a sidebar click, so focus advance, chat scroll transition, and the URL stay consistent, and it resolves `false` for an id the selected machine does not have.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -740,6 +740,7 @@ interface PluginRuntimeContext {
   configureAuth: () => void | Promise<void>;
   logoutAuth: () => void | Promise<void>;
   openThemePicker: () => void;
+  selectProject: (projectId: string, options?: { workspaceId?: string }) => Promise<boolean>;
   selectMainView: (view: string) => void;
   selectWorkspaceTool: (tool: QualifiedContributionId) => void;
   openTerminal: (options?: { terminalId?: string }) => void;
@@ -761,6 +762,7 @@ Notes:
 - Other `state` fields may exist at runtime, but they are private PI WEB internals that may graduate into stable helpers, change shape, or disappear.
 - `enabled` is evaluated when the action palette asks for actions.
 - `shortcutAliases` is for migration only: list former fully qualified action ids whose saved shortcut preference should still apply to this action.
+- `selectProject()` selects one of the selected machine's projects the same way the sidebar does, so focus, chat scroll transition, and the URL stay consistent. Pass `{ workspaceId }` to target a workspace inside it; without it the host applies its usual preferred-workspace choice. It resolves `false` when no project on the selected machine has that id, so a plugin can fall back instead of assuming the selection happened.
 - `selectWorkspaceTool()` expects a qualified panel id such as `my-plugin:workspace.info`.
 - `openTerminal()` switches to the built-in terminal panel. Pass `{ terminalId }` to deep-link to a specific terminal.
 - `refreshWorkspacePanels()` invokes `onInvalidate` for the selected workspace, either for every plugin panel or for one qualified `panelId`. The callback owns its refresh and should request a render when its visible state changes.

--- a/pi-web-plugins/git/pi-web-plugin.test.ts
+++ b/pi-web-plugins/git/pi-web-plugin.test.ts
@@ -331,6 +331,7 @@ function runtimeContext(patch: Partial<PluginRuntimeContext> = {}): PluginRuntim
     configureAuth: noop,
     logoutAuth: noop,
     openThemePicker: noop,
+    selectProject: () => Promise.resolve(false),
     selectMainView: noop,
     selectWorkspaceTool: noop,
     openTerminal: noop,

--- a/pi-web-plugins/info/pi-web-plugin.test.ts
+++ b/pi-web-plugins/info/pi-web-plugin.test.ts
@@ -58,6 +58,7 @@ function runtimeContext(patch: Partial<PluginRuntimeContext> = {}): PluginRuntim
     configureAuth: noop,
     logoutAuth: noop,
     openThemePicker: noop,
+    selectProject: () => Promise.resolve(false),
     selectMainView: noop,
     selectWorkspaceTool: noop,
     openTerminal: noop,

--- a/pi-web-plugins/updates/pi-web-plugin.test.ts
+++ b/pi-web-plugins/updates/pi-web-plugin.test.ts
@@ -37,6 +37,7 @@ function runtimeContext(patch: Partial<PluginRuntimeContext> = {}): PluginRuntim
     configureAuth: noop,
     logoutAuth: noop,
     openThemePicker: noop,
+    selectProject: () => Promise.resolve(false),
     selectMainView: noop,
     selectWorkspaceTool: noop,
     openTerminal: noop,

--- a/src/client/src/components/PiWebApp.pluginHost.test.ts
+++ b/src/client/src/components/PiWebApp.pluginHost.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { Workspace } from "../api";
+import type { Project, Workspace } from "../api";
 import { initialAppState } from "../appState";
 import { loadExternalPlugins, type PluginManifestEntry } from "../plugins/external";
 import { PluginRegistry } from "../plugins/registry";
@@ -16,6 +16,8 @@ const workspace: Workspace = {
   isMain: true,
   effectiveConfig: {},
 };
+
+const project: Project = { id: "project-1", name: "repo", path: "/repo", createdAt: "2026-01-01T00:00:00.000Z" };
 
 beforeEach(() => {
   vi.mocked(loadExternalPlugins).mockReset();
@@ -56,6 +58,36 @@ describe("PiWebApp plugin host", () => {
     await Promise.resolve();
 
     expect(invalidated).toHaveBeenCalledTimes(5);
+  });
+
+  it("selects a plugin-named project through the sidebar navigation seam", async () => {
+    const app = createApp();
+    setAppState(app, { ...initialAppState(), projects: [project] });
+    const selectProjectOnController = vi.fn(() => Promise.resolve(undefined));
+    stubWorkspaceProjectSelection(app, selectProjectOnController);
+    const navigated: [string, string][] = [];
+    stubNavigationSeam(app, navigated);
+
+    const selected = await createPluginRuntimeContext(app).selectProject(project.id, { workspaceId: workspace.id });
+
+    expect(selected).toBe(true);
+    expect(navigated).toEqual([["projects", "workspaces"]]);
+    expect(selectProjectOnController).toHaveBeenCalledWith(project, { workspaceId: workspace.id });
+  });
+
+  it("reports an unknown project id instead of selecting anything", async () => {
+    const app = createApp();
+    setAppState(app, { ...initialAppState(), projects: [project] });
+    const selectProjectOnController = vi.fn(() => Promise.resolve(undefined));
+    stubWorkspaceProjectSelection(app, selectProjectOnController);
+    const navigated: [string, string][] = [];
+    stubNavigationSeam(app, navigated);
+
+    const selected = await createPluginRuntimeContext(app).selectProject("missing-project");
+
+    expect(selected).toBe(false);
+    expect(navigated).toEqual([]);
+    expect(selectProjectOnController).not.toHaveBeenCalled();
   });
 
   it("keeps successful registrations while making an incomplete gateway load retryable", async () => {
@@ -177,6 +209,23 @@ async function ensureGatewayPluginsLoaded(app: PiWebApp): Promise<void> {
 function isPluginRuntimeContext(value: unknown): value is PluginRuntimeContext {
   if (typeof value !== "object" || value === null) return false;
   return "refreshWorkspacePanels" in value && typeof value.refreshWorkspacePanels === "function";
+}
+
+/* The seam under test is which navigation path a plugin selection takes, so the
+   controller call and the section advance are stubbed rather than the network: a real
+   selectProject would fetch workspaces and a real navigation advance would need a DOM. */
+function stubWorkspaceProjectSelection(app: PiWebApp, selectProject: (project: Project, target?: { workspaceId?: string }) => Promise<void>): void {
+  const workspaces: unknown = Reflect.get(app, "workspaces");
+  if (typeof workspaces !== "object" || workspaces === null) throw new Error("PiWebApp workspace controller was unavailable");
+  if (!Reflect.set(workspaces, "selectProject", selectProject)) throw new Error("Could not stub workspace project selection");
+}
+
+function stubNavigationSeam(app: PiWebApp, navigated: [string, string][]): void {
+  const seam = async (section: string, nextTarget: string, action: () => Promise<void>): Promise<void> => {
+    navigated.push([section, nextTarget]);
+    await action();
+  };
+  if (!Reflect.set(app, "selectNavigationItem", seam)) throw new Error("Could not stub navigation selection");
 }
 
 function stubPluginLoadRendering(app: PiWebApp): void {

--- a/src/client/src/components/PiWebApp.ts
+++ b/src/client/src/components/PiWebApp.ts
@@ -1292,6 +1292,16 @@ export class PiWebApp extends LitElement {
     this.navigationSections.open(section, () => { this.selectMainView("navigation"); });
   }
 
+  /* Plugin-facing project selection. Routed through the same navigation seam as a
+     sidebar click so focus advance, chat scroll transition, and URL update stay
+     identical; plugins have project ids but no way to reach the project objects. */
+  private async selectProjectById(projectId: string, options?: { workspaceId?: string }): Promise<boolean> {
+    const project = this.state.projects.find((candidate) => candidate.id === projectId);
+    if (project === undefined) return false;
+    await this.selectNavigationItem("projects", "workspaces", () => this.workspaces.selectProject(project, { workspaceId: options?.workspaceId }));
+    return true;
+  }
+
   private async selectNavigationItem(section: NavigationSection, nextTarget: NavigationFocusTarget, action: () => Promise<void>): Promise<void> {
     const seq = ++this.navigationSelectionSeq;
     const isCurrentSelection = () => seq === this.navigationSelectionSeq;
@@ -1737,6 +1747,7 @@ export class PiWebApp extends LitElement {
       openThemePicker: () => { this.openThemeDialog(); },
       openModelPicker: () => this.openModelDialog(),
       openThinkingLevelPicker: () => this.openThinkingDialog(),
+      selectProject: (projectId, options) => this.selectProjectById(projectId, options),
       selectMainView: (view) => { this.selectMainView(view); },
       selectWorkspaceTool: (tool) => { this.openWorkspaceTool(tool); },
       openTerminal: (options) => { this.openTerminal(options); },

--- a/src/client/src/plugins/registry.test.ts
+++ b/src/client/src/plugins/registry.test.ts
@@ -41,6 +41,7 @@ function createContext(statePatch: Partial<AppState> = {}) {
     openThemePicker: vi.fn(() => { calls.push("openThemePicker"); }),
     openModelPicker: vi.fn(() => { calls.push("openModelPicker"); }),
     openThinkingLevelPicker: vi.fn(() => { calls.push("openThinkingLevelPicker"); }),
+    selectProject: vi.fn((projectId: string) => { calls.push(`selectProject:${projectId}`); return Promise.resolve(true); }),
     selectMainView: vi.fn((view: AppState["mainView"]) => { calls.push(`selectMainView:${view}`); }),
     selectWorkspaceTool: vi.fn((tool: AppState["workspaceTool"]) => { calls.push(`selectWorkspaceTool:${tool}`); }),
     openTerminal: vi.fn((options?: { terminalId?: string | undefined }) => { calls.push(`openTerminal:${options?.terminalId ?? ""}`); }),

--- a/src/client/src/plugins/types.ts
+++ b/src/client/src/plugins/types.ts
@@ -124,6 +124,7 @@ export interface PluginRuntimeContext {
   openThemePicker: () => void;
   openModelPicker: () => void | Promise<void>;
   openThinkingLevelPicker: () => void | Promise<void>;
+  selectProject: (projectId: string, options?: { workspaceId?: string }) => Promise<boolean>;
   selectMainView: (view: AppState["mainView"]) => void;
   selectWorkspaceTool: (tool: QualifiedContributionId) => void;
   openTerminal: (options?: { terminalId?: string | undefined }) => void;

--- a/src/plugin-api.ts
+++ b/src/plugin-api.ts
@@ -104,6 +104,10 @@ export interface PluginRuntimeContext {
   configureAuth: () => void | Promise<void>;
   logoutAuth: () => void | Promise<void>;
   openThemePicker: () => void;
+  /** Select one of the selected machine's projects, optionally targeting a workspace
+   *  inside it. Without `workspaceId` the host applies its usual preferred-workspace
+   *  choice. Resolves false when no project on the selected machine has that id. */
+  selectProject: (projectId: string, options?: { workspaceId?: string }) => Promise<boolean>;
   selectMainView: (view: string) => void;
   selectWorkspaceTool: (tool: QualifiedContributionId) => void;
   openTerminal: (options?: { terminalId?: string | undefined }) => void;

--- a/test-fixtures/plugin-api-baseline/plugin-api.d.ts
+++ b/test-fixtures/plugin-api-baseline/plugin-api.d.ts
@@ -68,6 +68,12 @@ export interface PluginRuntimeContext {
     configureAuth: () => void | Promise<void>;
     logoutAuth: () => void | Promise<void>;
     openThemePicker: () => void;
+    /** Select one of the selected machine's projects, optionally targeting a workspace
+     *  inside it. Without `workspaceId` the host applies its usual preferred-workspace
+     *  choice. Resolves false when no project on the selected machine has that id. */
+    selectProject: (projectId: string, options?: {
+        workspaceId?: string;
+    }) => Promise<boolean>;
     selectMainView: (view: string) => void;
     selectWorkspaceTool: (tool: QualifiedContributionId) => void;
     openTerminal: (options?: {


### PR DESCRIPTION
## Why

A browser plugin can learn project ids, but it cannot act on them. `PluginRuntimeContext` can switch main views and workspace tools, yet a plugin that wants to move the user to another project has to navigate the page and reload the whole app.

Concretely: I maintain a workspace-provider plugin whose projects are working modes. Offering "go to that mode" meant `window.location.assign(...)` and a full reload, which throws away exactly the state the app just built.

## What

`selectProject(projectId, { workspaceId })` on the runtime context.

- Routes through the same navigation seam a sidebar click uses, so section focus advance, the chat scroll transition and the URL update stay identical.
- Without `workspaceId` the host keeps owning the preferred-workspace choice.
- Resolves `false` when no project on the selected machine has that id, so a plugin can fall back instead of assuming the selection happened.

Documented in `docs/plugins.md`, changeset included, and the public declaration baseline is updated for the intentional API change.

## Verification

Run on Node 24, the version CI uses: `typecheck`, `lint` and `knip` clean; suite 3398 passed / 2 failed. The two failures are in `src/server/dockerControlAssets.test.ts` and fail identically on unmodified `main` here, because my run happens inside a container.

## Note

No hard feelings if this is not a direction you want in the plugin API — feel free to close it. The change is small and self-contained, so it is easy to drop.