### PR TITLE
feat(plugins): add a headerItems contribution for plugin-owned header controls

### DIFF
--- a/.changeset/plugin-header-items.md
+++ b/.changeset/plugin-header-items.md
@@ -1,0 +1,5 @@
+---
+"@jmfederico/pi-web": minor
+---
+
+Add a `headerItems` browser plugin contribution: small always-visible controls in the navigation panel header, beside the machine switcher, and in the context bar on mobile. Intended for plugin-owned state that is not scoped to a workspace, such as a context switch or a global indicator.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -683,6 +683,7 @@ The workspace-related contribution arrays returned by `activate()` are:
 ```ts
 interface PluginContributions {
   actions?: PluginAction[];
+  headerItems?: HeaderItemContribution[];
   workspacePanels?: WorkspacePanelContribution[];
   workspaceLabels?: WorkspaceLabelContribution[];
 }
@@ -908,6 +909,47 @@ interface Workspace {
 `machine.id` is included in panel contexts so plugins can keep caches machine-scoped. Do not infer the selected machine from global browser state. Use the provider-authored `workspace.label` for provider-neutral presentation. `workspace.provider.pluginId` is the stable source id, and provider-published details such as Git status live in `workspace.provider.metadata`, which the server provider fills from browser-public `publicMetadata`. Provider-specific browser code may interpret metadata it owns; PI WEB core does not assign branch semantics to the generic workspace shape. `capabilities.remove` describes only this workspace, not the provider in general. The browser-v1 `isGitRepo`, `isGitWorktree`, and top-level `branch` aliases were removed.
 
 Use existing classes such as `toolbar`, `viewer`, `empty`, and `muted` for panel content when possible. Do not assume a panel owns the whole page; keep layout contained.
+
+### Header items
+
+Header items are small always-visible controls in the navigation panel header, on their own row under the app name and machine switcher. In the mobile layout, where that header is hidden, the same items appear in the context bar.
+
+Use them for plugin-owned state that is not scoped to one workspace and therefore has nowhere else to live: a context switch, a global indicator. Anything workspace-scoped belongs in a workspace panel or label instead.
+
+Keep the rendered control inline and compact. The panel can be as narrow as ~210px, and on mobile the items share a scrolling row with the context chips.
+
+```js
+headerItems: [
+  {
+    id: "mode",
+    title: "Working mode",
+    order: 10,
+    visible: ({ state }) => state.selectedMachine?.kind === "local",
+    render: ({ state, selectProject }) => html`
+      <my-mode-switcher .state=${state} .selectProject=${selectProject}></my-mode-switcher>
+    `,
+  },
+]
+```
+
+Header item contribution type:
+
+```ts
+interface HeaderItemContribution {
+  id: string;
+  title: string;
+  order?: number;
+  visible?: (context: PluginRuntimeContext) => boolean;
+  render: (context: PluginRuntimeContext) => TemplateResult;
+}
+```
+
+Notes:
+
+- `title` is the accessible name of the region the item renders into; it is not displayed as text.
+- `render` receives the same runtime context actions get, scoped to the contributing plugin, and runs on every app render, so keep it cheap and free of side effects.
+- Items are ordered by `order` (default 1000), then by qualified id.
+- Rendering a custom element keeps plugin styles inside its own shadow root instead of inheriting the header's.
 
 ### Workspace labels
 

--- a/src/client/src/components/PiWebApp.ts
+++ b/src/client/src/components/PiWebApp.ts
@@ -1283,6 +1283,7 @@ export class PiWebApp extends LitElement {
         .canStartSession=${!!this.state.selectedWorkspace}
         .collapsible=${true}
         .compact=${this.appShell.isMobileNavigationLayout}
+        .headerItems=${this.plugins.getHeaderItems(this.createPluginRuntimeContext())}
         .projectsCollapsed=${this.navigationSections.isCollapsed("projects")}
         .workspacesCollapsed=${this.navigationSections.isCollapsed("workspaces")}
         .sessionsCollapsed=${this.navigationSections.isCollapsed("sessions")}
@@ -2260,6 +2261,7 @@ export class PiWebApp extends LitElement {
         .project=${this.state.selectedProject}
         .workspace=${this.state.selectedWorkspace}
         .session=${this.state.selectedSession}
+        .headerItems=${this.plugins.getHeaderItems(this.createPluginRuntimeContext())}
         .refreshControl=${this.appShell.shouldShowAppRefreshInContextBar() ? this.renderAppRefresh() : undefined}
         .onOpenSection=${(section: NavigationSection) => { this.openNavigationSection(section); }}
         .onShowActions=${() => { this.setState({ actionPaletteOpen: true }); }}

--- a/src/client/src/components/appShell/AppContextBar.dom.test.ts
+++ b/src/client/src/components/appShell/AppContextBar.dom.test.ts
@@ -1,0 +1,22 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it } from "vitest";
+import { html } from "lit";
+import { AppContextBar } from "./AppContextBar";
+
+afterEach(() => {
+  document.body.replaceChildren();
+});
+
+describe("plugin header items in the context bar", () => {
+  it("carries the items the panel header cannot show in the mobile layout", async () => {
+    const bar = new AppContextBar();
+    bar.headerItems = [{ id: "modes:header.switch", title: "Working mode", render: () => html`<button class="mode">Cowork</button>` }];
+    document.body.append(bar);
+    await bar.updateComplete;
+
+    const group = bar.shadowRoot?.querySelector('.context-items [role="group"]');
+    expect(group?.getAttribute("aria-label")).toBe("Working mode");
+    expect(group?.querySelector("button.mode")?.textContent).toBe("Cowork");
+  });
+});

--- a/src/client/src/components/appShell/AppContextBar.ts
+++ b/src/client/src/components/appShell/AppContextBar.ts
@@ -3,6 +3,7 @@ import { customElement, property, query, state } from "lit/decorators.js";
 import type { Machine, Project, SessionInfo, Workspace } from "../../api";
 import { browserGatewayDisplayUrl, machineIconUrl } from "../../instanceIdentity";
 import { shortSessionId } from "../../sessionLabels";
+import type { HeaderItem } from "../../plugins/types";
 import type { NavigationSection } from "../../appShell/navigationState";
 
 @customElement("app-context-bar")
@@ -14,6 +15,7 @@ export class AppContextBar extends LitElement {
   @property({ attribute: false }) project?: Project;
   @property({ attribute: false }) workspace?: Workspace;
   @property({ attribute: false }) session?: SessionInfo;
+  @property({ attribute: false }) headerItems: readonly HeaderItem[] = [];
   @property({ attribute: false }) refreshControl: unknown;
   @property({ attribute: false }) onOpenSection?: (section: NavigationSection) => void;
   @property({ attribute: false }) onShowActions?: () => void;
@@ -54,6 +56,11 @@ export class AppContextBar extends LitElement {
       <nav class=${this.contextBarClass()} aria-label="Current location">
         <span class="context-bar-label">Location</span>
         <ol class="context-items" @scroll=${this.onContextScroll}>
+          ${this.headerItems.map((item) => html`
+            <li class="context-item">
+              <div class="context-plugin-item" role="group" aria-label=${item.title}>${item.render()}</div>
+            </li>
+          `)}
           ${showMachineChip ? html`
             <li class="context-item">
               ${machineChoice ? html`
@@ -177,6 +184,7 @@ export class AppContextBar extends LitElement {
     .context-bar.has-context-actions .context-items { padding-right: 58px; scroll-padding-inline: 8px 58px; }
     .context-bar.has-context-actions-double .context-items { padding-right: 102px; scroll-padding-inline: 8px 102px; }
     .context-item { flex: 0 0 auto; min-width: 0; display: flex; }
+    .context-plugin-item { display: flex; align-items: center; min-width: 0; }
     .context-actions { position: absolute; top: 6px; right: 0; bottom: 6px; z-index: 3; display: flex; align-items: center; gap: 6px; padding: 0 8px; background: var(--pi-bg); pointer-events: none; }
     .context-actions::before { content: ""; position: absolute; top: 0; bottom: 0; left: -24px; z-index: 0; width: 24px; background: linear-gradient(90deg, transparent, var(--pi-bg)); pointer-events: none; }
     app-refresh-control, .context-action-button { position: relative; z-index: 1; pointer-events: auto; }

--- a/src/client/src/components/appShell/AppNavigationPanel.test.ts
+++ b/src/client/src/components/appShell/AppNavigationPanel.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment happy-dom
 
 import { afterEach, describe, expect, it } from "vitest";
+import { html } from "lit";
 import type { Machine, Project, Workspace } from "../../api";
 import type { MachineStatusSnapshot } from "../../../../shared/machineStatus";
 import { machineStatusSnapshot } from "../../machineStatus.testSupport";
@@ -47,6 +48,27 @@ describe("header identity", () => {
   });
 });
 
+describe("plugin header items", () => {
+  it("renders each contributed item in the header under its own accessible name", async () => {
+    const panel = await mountPanelWithHeaderItems([
+      { id: "modes:header.switch", title: "Working mode", render: () => html`<button class="mode">Cowork</button>` },
+      { id: "status:header.badge", title: "Sync status", render: () => html`<span class="badge">2</span>` },
+    ]);
+
+    const groups = [...(panel.shadowRoot?.querySelectorAll(".header-items [role=\"group\"]") ?? [])];
+    expect(groups.map((group) => group.getAttribute("aria-label"))).toEqual(["Working mode", "Sync status"]);
+    expect(groups[0]?.querySelector("button.mode")?.textContent).toBe("Cowork");
+    expect(groups[1]?.querySelector("span.badge")?.textContent).toBe("2");
+  });
+
+  it("leaves no empty container when no plugin contributes one", async () => {
+    const panel = await mountPanelWithHeaderItems([]);
+
+    expect(panel.shadowRoot?.querySelector(".header-items")).toBeNull();
+    expect(panel.shadowRoot?.querySelector("header")).not.toBeNull();
+  });
+});
+
 describe("machine status wiring", () => {
   it("gives machine sections every snapshot and project and workspace sections the selected machine's", async () => {
     const local = machineStatusSnapshot({ machine: { "core:working": true } });
@@ -78,6 +100,17 @@ describe("machine status wiring", () => {
     expect(section(panel, "workspace-list", WorkspaceList).statusSnapshot).toBeUndefined();
   });
 });
+
+async function mountPanelWithHeaderItems(headerItems: AppNavigationPanel["headerItems"]): Promise<AppNavigationPanel> {
+  // Not compact: the header is hidden in the mobile layout, where the context bar
+  // carries these items instead.
+  const panel = new AppNavigationPanel();
+  panel.machines = [machine("local")];
+  panel.headerItems = headerItems;
+  document.body.append(panel);
+  await panel.updateComplete;
+  return panel;
+}
 
 async function mountPanel(machineStatusSnapshots: Record<string, MachineStatusSnapshot>, selectedMachine: Machine | undefined): Promise<AppNavigationPanel> {
   const panel = new AppNavigationPanel();

--- a/src/client/src/components/appShell/AppNavigationPanel.ts
+++ b/src/client/src/components/appShell/AppNavigationPanel.ts
@@ -2,7 +2,7 @@ import { LitElement, css, html } from "lit";
 import { customElement, property, query } from "lit/decorators.js";
 import type { Machine, MachineHealth, Project, SessionActivity, SessionInfo, SessionStatus, Workspace } from "../../api";
 import type { MachineStatusSnapshot } from "../../../../shared/machineStatus";
-import type { WorkspaceLabelItem } from "../../plugins/types";
+import type { HeaderItem, WorkspaceLabelItem } from "../../plugins/types";
 import { selectedMachineId } from "../../controllers/types";
 import type { NavigationSection } from "../../appShell/navigationState";
 import { NAVIGATION_SECTION_ORDER } from "../../appShell/navigationState";
@@ -38,6 +38,7 @@ export class AppNavigationPanel extends LitElement {
   @property({ attribute: false }) refreshControl: unknown;
   @property({ type: Boolean, reflect: true }) collapsible = false;
   @property({ type: Boolean, reflect: true }) compact = false;
+  @property({ attribute: false }) headerItems: readonly HeaderItem[] = [];
   @property({ type: Boolean }) machinesCollapsed = false;
   @property({ type: Boolean }) projectsCollapsed = false;
   @property({ type: Boolean }) workspacesCollapsed = false;
@@ -108,6 +109,11 @@ export class AppNavigationPanel extends LitElement {
           ${this.refreshControl}
           <button title="Show Actions" aria-label="Show Actions" @click=${() => { this.onShowActions?.(); }}>Actions</button>
         </div>
+        ${this.headerItems.length === 0 ? null : html`
+          <div class="header-items">
+            ${this.headerItems.map((item) => html`<div class="header-item" role="group" aria-label=${item.title}>${item.render()}</div>`)}
+          </div>
+        `}
       </header>
       ${this.compact && shouldShowMachinesSection(this.machines) ? html`
         <machine-list
@@ -219,10 +225,17 @@ export class AppNavigationPanel extends LitElement {
   static override styles = css`
     :host { display: flex; flex-direction: column; min-height: 0; overflow: hidden; }
     :host([compact]) { flex: 1 1 auto; }
-    header { flex: 0 0 auto; display: flex; align-items: center; justify-content: space-between; gap: 8px; padding: 12px; border-bottom: 1px solid var(--pi-border); }
+    header { flex: 0 0 auto; display: flex; flex-wrap: wrap; align-items: center; justify-content: space-between; gap: 8px; padding: 12px; border-bottom: 1px solid var(--pi-border); }
     header strong { flex: 0 0 auto; }
     machine-switcher { flex: 1 1 auto; min-width: 0; }
     :host([compact]) header { display: none; }
+    /* Contributed items take their own row instead of sharing the identity row: the panel
+       is often narrow (around 210px at an 800px window) and machine-switcher has
+       min-width: 0, so an item beside it squeezes the switcher to nothing. They render
+       after the actions row for the same reason wrap order matters — put them before it
+       and the Actions button wraps onto a third row. Both seen on a live stand, not
+       theorised. */
+    .header-items { flex: 1 1 100%; display: flex; align-items: center; gap: 8px; min-width: 0; }
     .header-actions { flex: 0 0 auto; display: flex; align-items: center; gap: 8px; }
     /* Expanded sections share the panel height equally, so collapsing one
        section distributes its space to every remaining section, not just the

--- a/src/client/src/plugins/registry.test.ts
+++ b/src/client/src/plugins/registry.test.ts
@@ -5,7 +5,7 @@ import { initialAppState, type AppState } from "../appState";
 import { markCachedNewSessionInfo } from "../cachedNewSessions";
 import { machineScopedPluginId } from "../../../shared/machinePluginIds";
 import { corePlugin } from "./core";
-import { PluginRegistry, installWorkspaceLabelScope, installWorkspacePanelScope } from "./registry";
+import { PluginRegistry, installPluginRuntimeScope, installWorkspaceLabelScope, installWorkspacePanelScope } from "./registry";
 import { themePackPlugin } from "./themes";
 import type { PiWebPlugin, PluginRuntimeContext, ThemeTokens, WorkspaceFiles, WorkspaceHost, WorkspaceLabelContext, WorkspaceLabelItem, WorkspacePanelContext, WorkspacePluginBinding } from "./types";
 import { createPluginWorkspaceBackend } from "./workspaceBackend";
@@ -553,6 +553,67 @@ describe("PluginRegistry", () => {
     expect(registry.getThemePairs().map((pair) => ({ id: pair.id, pluginId: pair.pluginId, localId: pair.localId, light: pair.light, dark: pair.dark }))).toEqual([
       { id: "example:pair", pluginId: "example", localId: "pair", light: "example:first", dark: "example:last" },
     ]);
+  });
+
+  it("collects header items in contribution order and drops hidden ones", () => {
+    const registry = new PluginRegistry();
+    registry.register({
+      id: "example",
+      plugin: {
+        apiVersion: 2,
+        name: "Example",
+        activate: ({ html }) => ({
+          contributions: {
+            headerItems: [
+              { id: "last", title: "Last", order: 20, render: () => html`<span>last</span>` },
+              { id: "hidden", title: "Hidden", order: 5, visible: () => false, render: () => html`<span>hidden</span>` },
+              { id: "first", title: "First", order: 10, render: () => html`<span>first</span>` },
+            ],
+          },
+        }),
+      },
+    });
+
+    expect(registry.getHeaderItems(createContext().context).map((item) => ({ id: item.id, title: item.title }))).toEqual([
+      { id: "example:first", title: "First" },
+      { id: "example:last", title: "Last" },
+    ]);
+  });
+
+  it("renders a header item with the contributing plugin's own runtime context", () => {
+    const registry = new PluginRegistry();
+    const seen: string[] = [];
+    registry.register({
+      id: "example",
+      plugin: {
+        apiVersion: 2,
+        name: "Example",
+        activate: ({ html }) => ({
+          contributions: {
+            headerItems: [{
+              id: "probe",
+              title: "Probe",
+              render: (context) => {
+                context.openTerminal({ terminalId: "from-header" });
+                seen.push(context.prompt.getText());
+                return html`<span>probe</span>`;
+              },
+            }],
+          },
+        }),
+      },
+    });
+
+    // Скоуп ставится так же, как его ставит приложение: контекст плагина отличается от
+    // общего, и рендер обязан получить свой. Без этого правка «не скоупить» была бы
+    // незаметной.
+    const { context, calls } = createContext();
+    const scoped = installPluginRuntimeScope(context, (pluginId) => ({ ...context, prompt: { ...context.prompt, getText: () => `scoped:${pluginId}` } }));
+    const [item] = registry.getHeaderItems(scoped);
+    item?.render();
+
+    expect(seen).toEqual(["scoped:example"]);
+    expect(calls).toEqual(["openTerminal:from-header"]);
   });
 
   it("collects workspace label items in contribution order", () => {

--- a/src/client/src/plugins/registry.ts
+++ b/src/client/src/plugins/registry.ts
@@ -1,6 +1,6 @@
 import { html, svg } from "lit";
 import { requirePluginBackendRevision } from "../../../shared/pluginBackendProtocol";
-import type { PiWebPluginRegistration, PluginAction, PluginRuntimeContext, QualifiedContributionId, QualifiedPluginAction, QualifiedThemeContribution, QualifiedThemePairContribution, QualifiedWorkspaceLabelContribution, QualifiedWorkspacePanelContribution, ThemeContribution, ThemePairContribution, WorkspaceLabelContext, WorkspaceLabelContribution, WorkspaceLabelItem, WorkspacePanelContext, WorkspacePanelContribution, WorkspacePluginBinding } from "./types";
+import type { HeaderItem, HeaderItemContribution, PiWebPluginRegistration, PluginAction, PluginRuntimeContext, QualifiedContributionId, QualifiedHeaderItemContribution, QualifiedPluginAction, QualifiedThemeContribution, QualifiedThemePairContribution, QualifiedWorkspaceLabelContribution, QualifiedWorkspacePanelContribution, ThemeContribution, ThemePairContribution, WorkspaceLabelContext, WorkspaceLabelContribution, WorkspaceLabelItem, WorkspacePanelContext, WorkspacePanelContribution, WorkspacePluginBinding } from "./types";
 
 const idPattern = /^[a-z][a-z0-9.-]*$/u;
 const localIdPattern = /^[a-z][a-z0-9.-]*$/u;
@@ -20,6 +20,7 @@ type RegisteredPluginAction = Omit<PluginAction, "id"> & {
 
 export class PluginRegistry {
   private readonly actions: RegisteredPluginAction[] = [];
+  private readonly headerItems: QualifiedHeaderItemContribution[] = [];
   private readonly workspacePanels: QualifiedWorkspacePanelContribution[] = [];
   private readonly workspaceLabels: QualifiedWorkspaceLabelContribution[] = [];
   private readonly themes: QualifiedThemeContribution[] = [];
@@ -57,6 +58,7 @@ export class PluginRegistry {
       const actions = (contributions.actions ?? []).map((action) => this.qualifyAction(runtimePluginId, action, registration.machineId, registration.sourcePluginId, contributionIds));
       const workspacePanels = (contributions.workspacePanels ?? []).map((panel) => this.qualifyWorkspacePanel(runtimePluginId, panel, registration.machineId, registration.sourcePluginId, backendRevision, contributionIds));
       const workspaceLabels = (contributions.workspaceLabels ?? []).map((contribution) => this.qualifyWorkspaceLabelContribution(runtimePluginId, contribution, registration.machineId, registration.sourcePluginId, backendRevision, contributionIds));
+      const headerItems = (contributions.headerItems ?? []).map((contribution) => this.qualifyHeaderItem(runtimePluginId, contribution, registration.machineId, registration.sourcePluginId, contributionIds));
       const themes = registration.machineId === undefined
         ? (contributions.themes ?? []).map((theme) => this.qualifyTheme(runtimePluginId, theme, contributionIds))
         : [];
@@ -67,6 +69,7 @@ export class PluginRegistry {
       this.pluginIds.add(runtimePluginId);
       for (const contributionId of contributionIds) this.contributionIds.add(contributionId);
       this.actions.push(...actions);
+      this.headerItems.push(...headerItems);
       this.workspacePanels.push(...workspacePanels);
       this.workspaceLabels.push(...workspaceLabels);
       this.themes.push(...themes);
@@ -112,6 +115,18 @@ export class PluginRegistry {
       if (disabledReason !== undefined && disabledReason !== "") qualified.disabledReason = disabledReason;
       return qualified;
     });
+  }
+
+  getHeaderItems(context: PluginRuntimeContext): HeaderItem[] {
+    const selectedMachineId = runtimeContextMachineId(context);
+    return [...this.headerItems]
+      .filter((item) => this.isContributionActive(item.pluginId, item.machineId, selectedMachineId, item.sourcePluginId))
+      .sort((left, right) => (left.order ?? 1000) - (right.order ?? 1000) || left.id.localeCompare(right.id))
+      .flatMap((item) => {
+        const scopedContext = pluginRuntimeContextFor(context, item.pluginId);
+        if (item.visible?.(scopedContext) === false) return [];
+        return [{ id: item.id, title: item.title, render: () => item.render(scopedContext) }];
+      });
   }
 
   getWorkspacePanels(): QualifiedWorkspacePanelContribution[] {
@@ -204,6 +219,24 @@ export class PluginRegistry {
       ...(badge === undefined ? {} : { badge: (context: WorkspacePanelContext) => this.isContributionActive(pluginId, machineId, context.machine.id, sourcePluginId) ? badge(workspacePanelContextFor(context, binding)) : undefined }),
       ...(onInvalidate === undefined ? {} : { onInvalidate: (context: WorkspacePanelContext) => this.isContributionActive(pluginId, machineId, context.machine.id, sourcePluginId) ? onInvalidate(workspacePanelContextFor(context, binding)) : undefined }),
       render: (context: WorkspacePanelContext) => panel.render(workspacePanelContextFor(context, binding)),
+    };
+  }
+
+  private qualifyHeaderItem(
+    pluginId: string,
+    contribution: HeaderItemContribution,
+    machineId: string | undefined,
+    sourcePluginId: string | undefined,
+    contributionIds: Set<QualifiedContributionId>,
+  ): QualifiedHeaderItemContribution {
+    const id = this.qualify(pluginId, contribution.id, contributionIds);
+    return {
+      ...contribution,
+      id,
+      pluginId,
+      localId: contribution.id,
+      ...(machineId === undefined ? {} : { machineId }),
+      ...(sourcePluginId === undefined ? {} : { sourcePluginId }),
     };
   }
 

--- a/src/client/src/plugins/types.ts
+++ b/src/client/src/plugins/types.ts
@@ -46,6 +46,7 @@ export interface PluginActivationResult {
 
 export interface PluginContributions {
   actions?: PluginAction[];
+  headerItems?: HeaderItemContribution[];
   workspacePanels?: WorkspacePanelContribution[];
   workspaceLabels?: WorkspaceLabelContribution[];
   themes?: ThemeContribution[];
@@ -241,6 +242,21 @@ export interface WorkspaceLabelRenderItem {
   render: () => TemplateResult;
 }
 
+export interface HeaderItemContribution {
+  id: LocalContributionId;
+  title: string;
+  order?: number;
+  visible?: (context: PluginRuntimeContext) => boolean;
+  render: (context: PluginRuntimeContext) => TemplateResult;
+}
+
+/** One header item resolved for rendering: the runtime context is already scoped. */
+export interface HeaderItem {
+  id: QualifiedContributionId;
+  title: string;
+  render: () => TemplateResult;
+}
+
 export interface WorkspaceLabelContribution {
   id: LocalContributionId;
   order?: number;
@@ -319,6 +335,14 @@ export interface QualifiedThemePairContribution extends Omit<ThemePairContributi
   localId: LocalContributionId;
   light: QualifiedContributionId;
   dark: QualifiedContributionId;
+}
+
+export interface QualifiedHeaderItemContribution extends HeaderItemContribution {
+  id: QualifiedContributionId;
+  pluginId: PluginId;
+  localId: LocalContributionId;
+  machineId?: string;
+  sourcePluginId?: string;
 }
 
 export interface QualifiedWorkspaceLabelContribution extends WorkspaceLabelContribution {

--- a/src/plugin-api.ts
+++ b/src/plugin-api.ts
@@ -62,10 +62,29 @@ export interface PluginActivationResult {
 
 export interface PluginContributions {
   actions?: PluginAction[];
+  headerItems?: HeaderItemContribution[];
   workspacePanels?: WorkspacePanelContribution[];
   workspaceLabels?: WorkspaceLabelContribution[];
   themes?: ThemeContribution[];
   themePairs?: ThemePairContribution[];
+}
+
+/**
+ * A small always-visible control in the navigation panel header, on its own row under the
+ * app name and machine switcher. Meant for plugin-owned state that is not scoped to one
+ * workspace and so has nowhere else to live: a context switch, a global indicator.
+ * Anything workspace-scoped belongs in a workspace panel or label instead.
+ *
+ * Keep it inline and compact: the panel can be as narrow as ~210px, and in the mobile
+ * layout the items share a scrolling row with the context chips.
+ */
+export interface HeaderItemContribution {
+  id: LocalContributionId;
+  /** Accessible name for the item's region. Not rendered as visible text. */
+  title: string;
+  order?: number;
+  visible?: (context: PluginRuntimeContext) => boolean;
+  render: (context: PluginRuntimeContext) => TemplateResult;
 }
 
 export interface PluginMachine {

--- a/test-fixtures/plugin-api-baseline/plugin-api.d.ts
+++ b/test-fixtures/plugin-api-baseline/plugin-api.d.ts
@@ -26,10 +26,28 @@ export interface PluginActivationResult {
 }
 export interface PluginContributions {
     actions?: PluginAction[];
+    headerItems?: HeaderItemContribution[];
     workspacePanels?: WorkspacePanelContribution[];
     workspaceLabels?: WorkspaceLabelContribution[];
     themes?: ThemeContribution[];
     themePairs?: ThemePairContribution[];
+}
+/**
+ * A small always-visible control in the navigation panel header, on its own row under the
+ * app name and machine switcher. Meant for plugin-owned state that is not scoped to one
+ * workspace and so has nowhere else to live: a context switch, a global indicator.
+ * Anything workspace-scoped belongs in a workspace panel or label instead.
+ *
+ * Keep it inline and compact: the panel can be as narrow as ~210px, and in the mobile
+ * layout the items share a scrolling row with the context chips.
+ */
+export interface HeaderItemContribution {
+    id: LocalContributionId;
+    /** Accessible name for the item's region. Not rendered as visible text. */
+    title: string;
+    order?: number;
+    visible?: (context: PluginRuntimeContext) => boolean;
+    render: (context: PluginRuntimeContext) => TemplateResult;
 }
 export interface PluginMachine {
     id: string;


### PR DESCRIPTION
## Why

A plugin has nowhere to put state that is not scoped to one workspace. Workspace panels and labels both hang off a selected workspace, and the action palette is only reachable once you already know the action exists. Anything global — a context switch, an indicator — has to hide inside a panel or not exist at all.

My case: a workspace-provider plugin whose projects are working modes. The mode switch belongs next to the app identity, not inside a workspace panel that only appears after you have already navigated to the right workspace.

## What

`headerItems`: small always-visible controls in the navigation panel header, on their own row under the app name and machine switcher. That header is hidden in the mobile layout, so the same items also render in the context bar — one contribution covers both surfaces.

- Items get the same runtime context actions get, scoped to the contributing plugin.
- Ordered by `order` (default 1000), then qualified id; `visible` can hide them.
- `title` is the accessible name of the item's region, not visible text.
- Rendering a custom element keeps the plugin's styles inside its own shadow root.

Two layout details are deliberate, both found on a live stand rather than reasoned about:

- items take a **row of their own** instead of sharing the identity row — the panel is often ~210px wide and `machine-switcher` has `min-width: 0`, so an item beside it squeezed the switcher to nothing;
- they render **after** the actions row — before it, wrap order pushed the Actions button onto a third row.

Documented in `docs/plugins.md`, changeset included, public declaration baseline updated.

## Verification

Typecheck, lint and knip clean; the touched suites (registry, app shell components, plugin host, plugin-api, build contents) pass on this base. The full suite passed on Node 24 — the version CI uses — for the same content before the rebase onto `main`: 2957 passed / 2 failed, the two being `src/server/dockerControlAssets.test.ts`, which fails identically on unmodified upstream here because my run happens inside a container.

## Note

Related, and independent: #196 (`selectProject` on the runtime context). A plugin that contributes a header switch needs both to be useful, but each stands on its own. Happy to close either if it is not a direction you want.