### PR TITLE
fix(mobile): keep the prompt composer visible above the keyboard on Chromium

### DIFF
--- a/.changeset/mobile-keyboard-composer.md
+++ b/.changeset/mobile-keyboard-composer.md
@@ -1,0 +1,5 @@
+---
+"@jmfederico/pi-web": patch
+---
+
+Add `interactive-widget=resizes-content` to the viewport meta so Chromium-based mobile browsers resize the layout viewport while the on-screen keyboard is open, keeping the prompt composer visible above the keyboard. Browsers that ignore the directive keep their current behaviour.

--- a/src/client/index.html
+++ b/src/client/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover, interactive-widget=resizes-content" />
     <title>PI WEB</title>
     <meta name="theme-color" content="#0d1117" />
     <link rel="icon" type="image/svg+xml" href="%BASE_URL%favicon.svg" />


### PR DESCRIPTION
## Summary

Replaces #186 with the minimum change requested in review.

- add `interactive-widget=resizes-content` to the viewport meta so Chromium based mobile browsers resize the layout viewport, and therefore `100dvh`, while the on-screen keyboard is open, keeping the prompt composer visible above the keyboard
- browsers that ignore the directive, notably Safari, keep their current behaviour
- the JS `KeyboardViewportController` from #186 is dropped per review

## Verification

Tested on real devices, with an A/B against a plain `main` build without the directive:

- **Android Chrome**: with the directive the layout viewport resizes and the composer docks above the keyboard. Without it the composer stays buried, matching the measurements from @janvitos in #186
- **iOS Safari**: the composer stays above the keyboard with or without the directive, no regression
- **iOS Chrome**: there is a pre-existing quirk where using the keyboard dismiss button leaves the composer buried on the next focus. It reproduces identically on plain `main` without the meta, so it is unrelated to this change and present before and after
- one patch changeset, typecheck and knip pass

Client only change, no session daemon or server behaviour touched.
