### PR TITLE
fix(chat): hide the activity dock while a session is idle

### DIFF
--- a/.changeset/hide-idle-activity-dock.md
+++ b/.changeset/hide-idle-activity-dock.md
@@ -1,0 +1,5 @@
+---
+"@jmfederico/pi-web": patch
+---
+
+Hide the chat activity dock while a session is idle and drop the bottom padding the chat reserved for it, so idle conversations get that vertical space back — most noticeable on phones.

--- a/src/client/src/components/ChatView.ts
+++ b/src/client/src/components/ChatView.ts
@@ -669,9 +669,9 @@ export class ChatView extends LitElement {
     }
     const state = this.activityState();
     if (state === undefined) return null;
-    const active = state !== "idle" || this.activity?.phase === "active";
+    if (state === "idle" && this.activity?.phase !== "active") return null;
     return html`
-      <div class=${active ? "activity-dock active" : "activity-dock"} aria-live="polite">
+      <div class="activity-dock active" aria-live="polite">
         <span class="dot"></span>
         <span class="activity-text">${this.activityText(state)}</span>
       </div>

--- a/src/client/src/components/shared.ts
+++ b/src/client/src/components/shared.ts
@@ -370,7 +370,9 @@ export const chatStyles = css`
     .notification-header { gap: 4px; padding-inline: 8px; }
     .notification-list { padding-inline: 8px; }
   }
-  .chat { --pi-chat-sticky-top: -26px; height: 100%; min-height: 0; overflow: auto; overflow-anchor: none; padding: 26px 16px 64px; box-sizing: border-box; }
+  .chat { --pi-chat-sticky-top: -26px; height: 100%; min-height: 0; overflow: auto; overflow-anchor: none; padding: 26px 16px 16px; box-sizing: border-box; }
+  /* Only reserve room for the absolutely positioned activity dock while it is rendered. */
+  .chat-wrap:has(.activity-dock) .chat { padding-bottom: 64px; }
   .scroll-marker { display: block; height: 0; overflow: hidden; pointer-events: none; }
   .activity-dock { position: absolute; left: 16px; right: 16px; bottom: 12px; z-index: 20; display: flex; align-items: center; gap: 8px; min-width: 0; box-sizing: border-box; border: 1px solid var(--pi-border); border-radius: 999px; background: var(--pi-bg-overlay); color: var(--pi-muted); padding: 8px 12px; font-size: 13px; pointer-events: none; box-shadow: 0 8px 28px var(--pi-shadow); backdrop-filter: blur(6px); }
   .activity-dock.active { border-color: var(--pi-success-border); color: var(--pi-success); background: var(--pi-success-bg-overlay); }


### PR DESCRIPTION
## Problem

The chat activity dock is absolutely positioned, and the chat reserves a fixed 64px of bottom padding for it whether or not it has anything to report. On phones that is a visible slice of the conversation permanently lost to a pill that just says "idle".

## Fix

Two small moves, no new abstractions:

- `renderActivityDock()` returns nothing for the idle form (idle state with no active activity report) instead of rendering a dimmed pill; since the dock now only ever renders in its active form, its class is unconditional.
- The chat bottom padding drops to 16px by default and reserves 64px only while a dock is actually on screen, via `.chat-wrap:has(.activity-dock) .chat` (`:has()` is already in use in `AskUserCard`).

The dock still appears for streaming, bash runs, compaction, queued messages, an in-flight send, and any active activity report.

## Verification

- `vitest run src/client/src/components/ChatView.test.ts` — 22/22 pass.
- Full `tsc --noEmit` passes.
- Changeset included (patch).

## Relationship to #179

Complementary, not overlapping: #179 stops the dock from *overlapping* message text by moving it into the flow below the transcript; this PR stops the dock from *existing at all* when the session is idle and there is nothing to report. The two touch the same `.chat` / `.activity-dock` rules in `shared.ts`, so whichever merges second will need a small rebase — with both applied, the dock would sit in its own row below the transcript and only appear while work is running. Happy to rebase on top of #179 if it lands first.