### PR TITLE
fix: add auth for web manifest, fixes deployments behind proxy

### DIFF
--- a/src/client/index.html
+++ b/src/client/index.html
@@ -7,7 +7,7 @@
     <meta name="theme-color" content="#0d1117" />
     <link rel="icon" type="image/svg+xml" href="%BASE_URL%favicon.svg" />
     <link rel="apple-touch-icon" href="%BASE_URL%apple-touch-icon.png" />
-    <link rel="manifest" href="%BASE_URL%manifest.webmanifest" />
+    <link rel="manifest" href="%BASE_URL%manifest.webmanifest" crossorigin="use-credentials" />
     <style>
       :root {
         color-scheme: dark;


### PR DESCRIPTION
When running pi-web behind an authenticating proxy, this is needed so the web manifest can load correctly.