### PR TITLE
feat(plugins): let a plugin name projects the project list should leave out

### DIFF
--- a/.changeset/plugin-hidden-projects.md
+++ b/.changeset/plugin-hidden-projects.md
@@ -1,0 +1,5 @@
+---
+"@jmfederico/pi-web": minor
+---
+
+Add a `hiddenProjects` browser plugin contribution: a plugin can name project ids the project section should leave out, for a provider whose projects are one implied context each and that already offers its own way in. The selected project is always listed, and a contribution that throws is skipped rather than breaking the list.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -683,6 +683,7 @@ The workspace-related contribution arrays returned by `activate()` are:
 ```ts
 interface PluginContributions {
   actions?: PluginAction[];
+  hiddenProjects?: HiddenProjectsContribution[];
   workspacePanels?: WorkspacePanelContribution[];
   workspaceLabels?: WorkspaceLabelContribution[];
 }
@@ -908,6 +909,28 @@ interface Workspace {
 `machine.id` is included in panel contexts so plugins can keep caches machine-scoped. Do not infer the selected machine from global browser state. Use the provider-authored `workspace.label` for provider-neutral presentation. `workspace.provider.pluginId` is the stable source id, and provider-published details such as Git status live in `workspace.provider.metadata`, which the server provider fills from browser-public `publicMetadata`. Provider-specific browser code may interpret metadata it owns; PI WEB core does not assign branch semantics to the generic workspace shape. `capabilities.remove` describes only this workspace, not the provider in general. The browser-v1 `isGitRepo`, `isGitWorktree`, and top-level `branch` aliases were removed.
 
 Use existing classes such as `toolbar`, `viewer`, `empty`, and `muted` for panel content when possible. Do not assume a panel owns the whole page; keep layout contained.
+
+### Hidden projects
+
+A plugin can ask the project section to leave some projects out:
+
+```js
+hiddenProjects: [
+  { id: "roots", projects: () => ["project-id-1", "project-id-2"] },
+]
+```
+
+Use it for a provider whose projects are one implied context each and that already offers its own way in. A row in the project list is then a second door into a place the plugin navigates to itself, on a panel where space is scarce.
+
+The host cannot work this out alone: it learns a project's provider only after resolving that project's workspaces, and it does that lazily for the selected project. A plugin that navigates between such projects has usually resolved them already.
+
+Notes:
+
+- The bargain is explicit — hiding a project means the plugin takes responsibility for offering the way in.
+- The **selected** project is always listed, so what you are working in never disappears from navigation.
+- `projects()` runs on every render: return a cached list, do not fetch.
+- A `projects()` that throws is logged and skipped; other plugins' hidden lists still apply.
+- Hidden projects stay reachable by URL and by adding them again, so nothing becomes permanently unreachable.
 
 ### Workspace labels
 

--- a/src/client/src/components/PiWebApp.pluginHost.test.ts
+++ b/src/client/src/components/PiWebApp.pluginHost.test.ts
@@ -58,6 +58,31 @@ describe("PiWebApp plugin host", () => {
     expect(invalidated).toHaveBeenCalledTimes(5);
   });
 
+  it("leaves plugin-hidden projects out of the list but never the selected one", () => {
+    const chat = { id: "p-chat", name: "chat", path: "/home/node/chat", createdAt: "2026-01-01T00:00:00.000Z" };
+    const repo = { id: "p-repo", name: "repo", path: "/repo", createdAt: "2026-01-01T00:00:00.000Z" };
+    const app = createApp();
+    setAppState(app, { ...initialAppState(), projects: [chat, repo] });
+    appPluginRegistry(app).register({
+      id: "modes",
+      plugin: {
+        apiVersion: 2,
+        name: "Modes",
+        activate: () => ({ contributions: { hiddenProjects: [{ id: "roots", projects: () => ["p-chat"] }] } }),
+      },
+    });
+
+    expect(listedProjectIds(app)).toEqual(["p-repo"]);
+    // И панель обязана получить именно этот список, а не state.projects: иначе фильтр
+    // существует, но ни на что не влияет (мутация «фильтр не применяется» это показала).
+    expect(projectIdsHandedToPanel(app)).toEqual(["p-repo"]);
+
+    // Работая внутри скрытого проекта, человек обязан видеть, где он находится.
+    setAppState(app, { ...initialAppState(), projects: [chat, repo], selectedProject: chat });
+    expect(listedProjectIds(app)).toEqual(["p-chat", "p-repo"]);
+    expect(projectIdsHandedToPanel(app)).toEqual(["p-chat", "p-repo"]);
+  });
+
   it("keeps successful registrations while making an incomplete gateway load retryable", async () => {
     const app = createApp();
     stubPluginLoadRendering(app);
@@ -146,6 +171,40 @@ function createApp(): PiWebApp {
   };
   vi.stubGlobal("window", { location: { search: "" }, localStorage: storage });
   return new PiWebApp();
+}
+
+function projectId(value: object): string {
+  const id: unknown = Reflect.get(value, "id");
+  return typeof id === "string" ? id : "";
+}
+
+/* Что панель реально получает в .projects. Узкая лазейка из testing-guide: разбираем
+   TemplateResult вместо DOM — поднимать всё приложение в happy-dom ради одного свойства
+   дороже и хрупче, чем найти переданный массив проектов среди значений шаблона. */
+function projectIdsHandedToPanel(app: PiWebApp): string[] {
+  const template: unknown = callAppMethod(app, "renderNavigationPanel");
+  if (typeof template !== "object" || template === null || !("values" in template)) throw new Error("PiWebApp navigation panel template was unavailable");
+  const values: unknown = Reflect.get(template, "values");
+  if (!Array.isArray(values)) throw new Error("PiWebApp navigation panel template had no values");
+  const looksLikeProjects = (value: unknown): value is object[] =>
+    Array.isArray(value) && value.length > 0
+    && value.every((item) => typeof item === "object" && item !== null && "path" in item && "createdAt" in item && !("projectId" in item));
+  const projects = values.find(looksLikeProjects);
+  if (projects === undefined) throw new Error("PiWebApp handed the navigation panel no project list");
+  return projects.map(projectId);
+}
+
+function listedProjectIds(app: PiWebApp): string[] {
+  const listed: unknown = callAppMethod(app, "listedProjects");
+  if (!Array.isArray(listed)) throw new Error("PiWebApp listed projects were unavailable");
+  const length: unknown = Reflect.get(listed, "length");
+  const count = typeof length === "number" ? length : 0;
+  const ids: string[] = [];
+  for (let index = 0; index < count; index += 1) {
+    const project: unknown = Reflect.get(listed, String(index));
+    ids.push(typeof project === "object" && project !== null ? projectId(project) : "");
+  }
+  return ids;
 }
 
 function setAppState(app: PiWebApp, state: ReturnType<typeof initialAppState>): void {

--- a/src/client/src/components/PiWebApp.ts
+++ b/src/client/src/components/PiWebApp.ts
@@ -1268,7 +1268,7 @@ export class PiWebApp extends LitElement {
         .onToggleMachines=${() => { this.navigationSections.toggle("machines"); }}
         .onSelectMachine=${(machine: Machine) => this.selectNavigationItem("machines", "projects", () => this.selectMachineWithMemory(machine))}
         .onRemoveMachine=${(machine: Machine) => { void this.removeMachine(machine); }}
-        .projects=${this.state.projects}
+        .projects=${this.listedProjects()}
         .selectedProject=${this.state.selectedProject}
         .workspaces=${this.state.workspaces}
         .selectedWorkspace=${this.state.selectedWorkspace}
@@ -1319,6 +1319,16 @@ export class PiWebApp extends LitElement {
 
   private openNavigationSection(section: NavigationSection): void {
     this.navigationSections.open(section, () => { this.selectMainView("navigation"); });
+  }
+
+  /* Проекты, которые показывает панель. Плагин может попросить не показывать свои — но
+     выбранный проект остаётся в списке всегда: то, в чём человек сейчас работает, не
+     должно исчезать из навигации. */
+  private listedProjects(): Project[] {
+    const hidden = this.plugins.getHiddenProjectIds(this.createPluginRuntimeContext());
+    if (hidden.size === 0) return this.state.projects;
+    const selectedId = this.state.selectedProject?.id;
+    return this.state.projects.filter((project) => !hidden.has(project.id) || project.id === selectedId);
   }
 
   private async selectNavigationItem(section: NavigationSection, nextTarget: NavigationFocusTarget, action: () => Promise<void>): Promise<void> {

--- a/src/client/src/plugins/registry.test.ts
+++ b/src/client/src/plugins/registry.test.ts
@@ -555,6 +555,52 @@ describe("PluginRegistry", () => {
     ]);
   });
 
+  it("collects hidden project ids from every active plugin", () => {
+    const registry = new PluginRegistry();
+    registry.register({
+      id: "modes",
+      plugin: {
+        apiVersion: 2,
+        name: "Modes",
+        activate: () => ({ contributions: { hiddenProjects: [{ id: "roots", projects: () => ["p-chat", "p-cowork", ""] }] } }),
+      },
+    });
+    registry.register({
+      id: "other",
+      plugin: {
+        apiVersion: 2,
+        name: "Other",
+        activate: () => ({ contributions: { hiddenProjects: [{ id: "roots", projects: () => ["p-other"] }] } }),
+      },
+    });
+
+    expect([...registry.getHiddenProjectIds(createContext().context)].sort()).toEqual(["p-chat", "p-cowork", "p-other"]);
+  });
+
+  it("keeps the list usable when a plugin throws instead of naming projects", () => {
+    const registry = new PluginRegistry();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    registry.register({
+      id: "broken",
+      plugin: {
+        apiVersion: 2,
+        name: "Broken",
+        activate: () => ({ contributions: { hiddenProjects: [{ id: "roots", projects: () => { throw new Error("nope"); } }] } }),
+      },
+    });
+    registry.register({
+      id: "modes",
+      plugin: {
+        apiVersion: 2,
+        name: "Modes",
+        activate: () => ({ contributions: { hiddenProjects: [{ id: "roots", projects: () => ["p-chat"] }] } }),
+      },
+    });
+
+    expect([...registry.getHiddenProjectIds(createContext().context)]).toEqual(["p-chat"]);
+    expect(warn).toHaveBeenCalledOnce();
+  });
+
   it("collects workspace label items in contribution order", () => {
     const registry = new PluginRegistry();
     const workspace = testWorkspace();

--- a/src/client/src/plugins/registry.ts
+++ b/src/client/src/plugins/registry.ts
@@ -1,6 +1,6 @@
 import { html, svg } from "lit";
 import { requirePluginBackendRevision } from "../../../shared/pluginBackendProtocol";
-import type { PiWebPluginRegistration, PluginAction, PluginRuntimeContext, QualifiedContributionId, QualifiedPluginAction, QualifiedThemeContribution, QualifiedThemePairContribution, QualifiedWorkspaceLabelContribution, QualifiedWorkspacePanelContribution, ThemeContribution, ThemePairContribution, WorkspaceLabelContext, WorkspaceLabelContribution, WorkspaceLabelItem, WorkspacePanelContext, WorkspacePanelContribution, WorkspacePluginBinding } from "./types";
+import type { HiddenProjectsContribution, PiWebPluginRegistration, PluginAction, PluginRuntimeContext, QualifiedContributionId, QualifiedHiddenProjectsContribution, QualifiedPluginAction, QualifiedThemeContribution, QualifiedThemePairContribution, QualifiedWorkspaceLabelContribution, QualifiedWorkspacePanelContribution, ThemeContribution, ThemePairContribution, WorkspaceLabelContext, WorkspaceLabelContribution, WorkspaceLabelItem, WorkspacePanelContext, WorkspacePanelContribution, WorkspacePluginBinding } from "./types";
 
 const idPattern = /^[a-z][a-z0-9.-]*$/u;
 const localIdPattern = /^[a-z][a-z0-9.-]*$/u;
@@ -20,6 +20,7 @@ type RegisteredPluginAction = Omit<PluginAction, "id"> & {
 
 export class PluginRegistry {
   private readonly actions: RegisteredPluginAction[] = [];
+  private readonly hiddenProjects: QualifiedHiddenProjectsContribution[] = [];
   private readonly workspacePanels: QualifiedWorkspacePanelContribution[] = [];
   private readonly workspaceLabels: QualifiedWorkspaceLabelContribution[] = [];
   private readonly themes: QualifiedThemeContribution[] = [];
@@ -57,6 +58,7 @@ export class PluginRegistry {
       const actions = (contributions.actions ?? []).map((action) => this.qualifyAction(runtimePluginId, action, registration.machineId, registration.sourcePluginId, contributionIds));
       const workspacePanels = (contributions.workspacePanels ?? []).map((panel) => this.qualifyWorkspacePanel(runtimePluginId, panel, registration.machineId, registration.sourcePluginId, backendRevision, contributionIds));
       const workspaceLabels = (contributions.workspaceLabels ?? []).map((contribution) => this.qualifyWorkspaceLabelContribution(runtimePluginId, contribution, registration.machineId, registration.sourcePluginId, backendRevision, contributionIds));
+      const hiddenProjects = (contributions.hiddenProjects ?? []).map((contribution) => this.qualifyHiddenProjects(runtimePluginId, contribution, registration.machineId, registration.sourcePluginId, contributionIds));
       const themes = registration.machineId === undefined
         ? (contributions.themes ?? []).map((theme) => this.qualifyTheme(runtimePluginId, theme, contributionIds))
         : [];
@@ -67,6 +69,7 @@ export class PluginRegistry {
       this.pluginIds.add(runtimePluginId);
       for (const contributionId of contributionIds) this.contributionIds.add(contributionId);
       this.actions.push(...actions);
+      this.hiddenProjects.push(...hiddenProjects);
       this.workspacePanels.push(...workspacePanels);
       this.workspaceLabels.push(...workspaceLabels);
       this.themes.push(...themes);
@@ -112,6 +115,26 @@ export class PluginRegistry {
       if (disabledReason !== undefined && disabledReason !== "") qualified.disabledReason = disabledReason;
       return qualified;
     });
+  }
+
+  /** Project ids plugins asked to leave out of the project list. */
+  getHiddenProjectIds(context: PluginRuntimeContext): Set<string> {
+    const selectedMachineId = runtimeContextMachineId(context);
+    const hidden = new Set<string>();
+    for (const contribution of this.hiddenProjects) {
+      if (!this.isContributionActive(contribution.pluginId, contribution.machineId, selectedMachineId, contribution.sourcePluginId)) continue;
+      const scopedContext = pluginRuntimeContextFor(context, contribution.pluginId);
+      let ids: readonly string[];
+      try {
+        ids = contribution.projects(scopedContext);
+      } catch (error) {
+        // Плагин не должен уметь спрятать список проектов целиком, уронив рендер панели.
+        console.warn(`Failed to read hidden projects from PI WEB plugin ${contribution.id}`, error);
+        continue;
+      }
+      for (const id of ids) if (typeof id === "string" && id !== "") hidden.add(id);
+    }
+    return hidden;
   }
 
   getWorkspacePanels(): QualifiedWorkspacePanelContribution[] {
@@ -204,6 +227,24 @@ export class PluginRegistry {
       ...(badge === undefined ? {} : { badge: (context: WorkspacePanelContext) => this.isContributionActive(pluginId, machineId, context.machine.id, sourcePluginId) ? badge(workspacePanelContextFor(context, binding)) : undefined }),
       ...(onInvalidate === undefined ? {} : { onInvalidate: (context: WorkspacePanelContext) => this.isContributionActive(pluginId, machineId, context.machine.id, sourcePluginId) ? onInvalidate(workspacePanelContextFor(context, binding)) : undefined }),
       render: (context: WorkspacePanelContext) => panel.render(workspacePanelContextFor(context, binding)),
+    };
+  }
+
+  private qualifyHiddenProjects(
+    pluginId: string,
+    contribution: HiddenProjectsContribution,
+    machineId: string | undefined,
+    sourcePluginId: string | undefined,
+    contributionIds: Set<QualifiedContributionId>,
+  ): QualifiedHiddenProjectsContribution {
+    const id = this.qualify(pluginId, contribution.id, contributionIds);
+    return {
+      ...contribution,
+      id,
+      pluginId,
+      localId: contribution.id,
+      ...(machineId === undefined ? {} : { machineId }),
+      ...(sourcePluginId === undefined ? {} : { sourcePluginId }),
     };
   }
 

--- a/src/client/src/plugins/types.ts
+++ b/src/client/src/plugins/types.ts
@@ -46,6 +46,7 @@ export interface PluginActivationResult {
 
 export interface PluginContributions {
   actions?: PluginAction[];
+  hiddenProjects?: HiddenProjectsContribution[];
   workspacePanels?: WorkspacePanelContribution[];
   workspaceLabels?: WorkspaceLabelContribution[];
   themes?: ThemeContribution[];
@@ -239,6 +240,19 @@ export interface WorkspaceLabelLinkItem {
 export interface WorkspaceLabelRenderItem {
   type: "render";
   render: () => TemplateResult;
+}
+
+export interface HiddenProjectsContribution {
+  id: LocalContributionId;
+  projects: (context: PluginRuntimeContext) => readonly string[];
+}
+
+export interface QualifiedHiddenProjectsContribution extends HiddenProjectsContribution {
+  id: QualifiedContributionId;
+  pluginId: PluginId;
+  localId: LocalContributionId;
+  machineId?: string;
+  sourcePluginId?: string;
 }
 
 export interface WorkspaceLabelContribution {

--- a/src/plugin-api.ts
+++ b/src/plugin-api.ts
@@ -62,6 +62,7 @@ export interface PluginActivationResult {
 
 export interface PluginContributions {
   actions?: PluginAction[];
+  hiddenProjects?: HiddenProjectsContribution[];
   workspacePanels?: WorkspacePanelContribution[];
   workspaceLabels?: WorkspaceLabelContribution[];
   themes?: ThemeContribution[];
@@ -203,6 +204,27 @@ export interface WorkspacePanelContext extends WorkspaceContext {
 }
 
 export type WorkspacePanelIcon = TemplateResult;
+
+/**
+ * Projects the project section should not list, named by the plugin that already knows
+ * how to reach them.
+ *
+ * For a provider whose projects are one implied context each, a row in the project list is
+ * a second door into a place the plugin already offers its own way into — and the section
+ * is a scarce resource on a narrow panel. The host cannot work this out by itself: it
+ * learns a project's provider only after resolving that project's workspaces, and it does
+ * that lazily for the selected project alone. The plugin usually resolved them already.
+ *
+ * The bargain is explicit: hiding a project means the plugin takes responsibility for
+ * offering the way in. The host keeps two guarantees regardless — the selected project is
+ * always listed, so nothing you are working in disappears, and every project stays
+ * reachable by URL and by adding it again.
+ */
+export interface HiddenProjectsContribution {
+  id: LocalContributionId;
+  /** Project ids to leave out of the list. Called on every render, so keep it cheap. */
+  projects: (context: PluginRuntimeContext) => readonly string[];
+}
 
 export interface WorkspacePanelContribution {
   id: LocalContributionId;

--- a/test-fixtures/plugin-api-baseline/plugin-api.d.ts
+++ b/test-fixtures/plugin-api-baseline/plugin-api.d.ts
@@ -26,6 +26,7 @@ export interface PluginActivationResult {
 }
 export interface PluginContributions {
     actions?: PluginAction[];
+    hiddenProjects?: HiddenProjectsContribution[];
     workspacePanels?: WorkspacePanelContribution[];
     workspaceLabels?: WorkspaceLabelContribution[];
     themes?: ThemeContribution[];
@@ -159,6 +160,26 @@ export interface WorkspacePanelContext extends WorkspaceContext {
     terminal: WorkspacePanelTerminal;
 }
 export type WorkspacePanelIcon = TemplateResult;
+/**
+ * Projects the project section should not list, named by the plugin that already knows
+ * how to reach them.
+ *
+ * For a provider whose projects are one implied context each, a row in the project list is
+ * a second door into a place the plugin already offers its own way into — and the section
+ * is a scarce resource on a narrow panel. The host cannot work this out by itself: it
+ * learns a project's provider only after resolving that project's workspaces, and it does
+ * that lazily for the selected project alone. The plugin usually resolved them already.
+ *
+ * The bargain is explicit: hiding a project means the plugin takes responsibility for
+ * offering the way in. The host keeps two guarantees regardless — the selected project is
+ * always listed, so nothing you are working in disappears, and every project stays
+ * reachable by URL and by adding it again.
+ */
+export interface HiddenProjectsContribution {
+    id: LocalContributionId;
+    /** Project ids to leave out of the list. Called on every render, so keep it cheap. */
+    projects: (context: PluginRuntimeContext) => readonly string[];
+}
 export interface WorkspacePanelContribution {
     id: LocalContributionId;
     title: string;


### PR DESCRIPTION
## Why

A workspace provider whose projects are one implied context each already offers its own way in. A row in the project list is then a second door into the same place — on a panel that is often around 210px wide, where the project section is the widest thing on screen.

The host cannot work this out by itself: it learns a project's provider only after resolving that project's workspaces, and it does that lazily for the selected project alone. A plugin that navigates between such projects has usually resolved them already, so this puts the decision where the knowledge already is.

My case: a provider whose projects are working modes, with a switch in the header. The mode projects appearing again in the repository list is pure noise.

## What

```js
hiddenProjects: [
  { id: "roots", projects: () => ["project-id-1", "project-id-2"] },
]
```

The bargain is explicit — hiding a project means the plugin takes responsibility for offering the way in. The host keeps two guarantees regardless:

- the **selected** project is always listed, so nothing you are working in disappears from navigation;
- hidden projects stay reachable by URL and by adding them again, so nothing becomes permanently unreachable.

A `projects()` that throws is logged and skipped rather than breaking the list, and the ids are read on every render, so the contract says to return a cached list rather than fetch.

Documented in `docs/plugins.md`, changeset included, public declaration baseline updated.

## Verification

Typecheck, lint and knip clean; the affected suites (registry, plugin host, plugin-api, build contents) pass on this base. The full suite passed on Node 24 — the version CI uses — for the same content before the rebase onto `main`: 2955 passed / 2 failed, the two being `src/server/dockerControlAssets.test.ts`, which fails identically on unmodified upstream here because my run happens inside a container.

## Note

This is the most opinionated of the four I have opened (#196, #198, #199) — it asks the host to trust a plugin's claim that a way in exists. The two guarantees above are there precisely to bound that trust, but if the direction is not one you want, closing it costs nothing: it is additive and self-contained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)