### PR TITLE
perf(chat): load oversized inline images on demand instead of base64-inlining them in the messages page

### DIFF
--- a/.changeset/lazy-media-references.md
+++ b/.changeset/lazy-media-references.md
@@ -1,0 +1,5 @@
+---
+"@jmfederico/pi-web": patch
+---
+
+Open image-heavy sessions quickly: oversized inline images now load on demand through a media endpoint instead of riding along as base64 inside the first messages page.

--- a/src/server/browserMessageProjection.test.ts
+++ b/src/server/browserMessageProjection.test.ts
@@ -58,4 +58,43 @@ describe("browser message projection", () => {
     expect(projectBrowserSessionEvent(appendEvent)).toBe(appendEvent);
     expect(finalEvent.message).toBe(message);
   });
+
+  it("replaces oversized inline images with media references and keeps small ones inline", () => {
+    const bigData = "A".repeat(80 * 1024);
+    const smallData = "c2hvcnQtaW1hZ2U=";
+    const message = {
+      role: "toolResult",
+      toolName: "read",
+      content: [
+        { type: "image", mimeType: "image/png", data: bigData },
+        { type: "image", mimeType: "image/png", data: smallData },
+      ],
+    };
+    const mediaIds: string[] = [];
+    const projected = projectBrowserMessage(message, {
+      inlineLimit: 64 * 1024,
+      mediaSrc: (mediaId) => {
+        mediaIds.push(mediaId);
+        return `api/machines/local/sessions/s1/media/${mediaId}?cwd=%2Frepo`;
+      },
+    });
+
+    expect(projected).toEqual({
+      role: "toolResult",
+      toolName: "read",
+      content: [
+        { type: "image", mimeType: "image/png", src: `api/machines/local/sessions/s1/media/${mediaIds[0] ?? ""}?cwd=%2Frepo`, byteSize: 60 * 1024 },
+        { type: "image", mimeType: "image/png", data: smallData },
+      ],
+    });
+    expect(mediaIds).toHaveLength(1);
+    expect(message.content[0]).toEqual({ type: "image", mimeType: "image/png", data: bigData });
+  });
+
+  it("keeps oversized images inline when no media source is available", () => {
+    const bigData = "A".repeat(80 * 1024);
+    const message = { role: "toolResult", content: [{ type: "image", mimeType: "image/png", data: bigData }] };
+
+    expect(projectBrowserMessage(message)).toBe(message);
+  });
 });

--- a/src/server/browserMessageProjection.ts
+++ b/src/server/browserMessageProjection.ts
@@ -1,33 +1,67 @@
+import { createHash } from "node:crypto";
 import type { MessagePage, SessionUiEvent } from "../shared/apiTypes.js";
 
 /**
- * Remove provider-only thinking data at the browser transport boundary. The
- * runtime message remains unchanged because only affected messages and content
- * blocks are copied.
+ * Media-reference behaviour for one browser projection pass. The caller turns
+ * a request-level opt-in (for example a `maxInlineMedia` query parameter) into
+ * this shape; without it images stay fully inline.
  */
-export function projectBrowserMessage(message: unknown): unknown {
+export interface BrowserMediaProjection {
+  /** Build the application-relative URL a browser fetches an oversized image from. */
+  mediaSrc(mediaId: string): string;
+  /** Inline base64 length above which an image part becomes a media reference. */
+  inlineLimit: number;
+}
+
+/**
+ * Remove provider-only thinking data and, when a media projection is supplied,
+ * replace oversized inline images with on-demand media references at the
+ * browser transport boundary. The runtime message remains unchanged because
+ * only affected messages and content blocks are copied.
+ */
+export function projectBrowserMessage(message: unknown, media?: BrowserMediaProjection): unknown {
   if (!isRecord(message)) return message;
   const originalContent = message["content"];
   if (!isUnknownArray(originalContent)) return message;
 
   const content = mapChanged(originalContent, (part) => {
-    if (!isRecord(part) || part["type"] !== "thinking" || !Object.hasOwn(part, "thinkingSignature")) return part;
-    const projected = { ...part };
-    delete projected["thinkingSignature"];
-    return projected;
+    if (!isRecord(part)) return part;
+    if (part["type"] === "thinking") {
+      if (!Object.hasOwn(part, "thinkingSignature")) return part;
+      const projected = { ...part };
+      delete projected["thinkingSignature"];
+      return projected;
+    }
+    if (part["type"] === "image") {
+      const data = part["data"];
+      if (media === undefined || typeof data !== "string" || data.length <= media.inlineLimit) return part;
+      const mimeType = typeof part["mimeType"] === "string" && part["mimeType"] !== "" ? part["mimeType"] : "application/octet-stream";
+      return {
+        type: "image",
+        mimeType,
+        src: media.mediaSrc(mediaIdForData(data)),
+        byteSize: Math.floor((data.length * 3) / 4),
+      };
+    }
+    return part;
   });
 
   return content === originalContent ? message : { ...message, content };
 }
 
-export function projectBrowserMessageResponse(response: MessagePage): MessagePage {
-  const messages = mapChanged(response.messages, projectBrowserMessage);
+/** Content-hash id used to fetch an oversized image from the media endpoint. */
+export function mediaIdForData(data: string): string {
+  return createHash("sha256").update(data).digest("hex");
+}
+
+export function projectBrowserMessageResponse(response: MessagePage, media?: BrowserMediaProjection): MessagePage {
+  const messages = mapChanged(response.messages, (message) => projectBrowserMessage(message, media));
   return messages === response.messages ? response : { ...response, messages };
 }
 
-export function projectBrowserSessionEvent(event: SessionUiEvent): SessionUiEvent {
+export function projectBrowserSessionEvent(event: SessionUiEvent, media?: BrowserMediaProjection): SessionUiEvent {
   if (event.type !== "message.end" || event.message === undefined) return event;
-  const message = projectBrowserMessage(event.message);
+  const message = projectBrowserMessage(event.message, media);
   return message === event.message ? event : { ...event, message };
 }
 

--- a/src/server/sessions/piSessionService.ts
+++ b/src/server/sessions/piSessionService.ts
@@ -28,7 +28,7 @@ import {
   type ResourceDiagnostic,
 } from "@earendil-works/pi-coding-agent";
 import type { ClientArchiveSessionsResponse, ClientCommand, ClientCommandResult, ClientMessagePage, ClientSession, ClientSessionCleanupExecuteResponse, ClientSessionCleanupPreviewResponse, ClientSessionModel, ClientSessionModelCatalogEntry, ClientSessionStatus, ClientSessionTreeForkRequest, ClientSessionTreeForkResult, ClientSessionTreeNavigateRequest, ClientSessionTreeNavigateResult, ClientThinkingLevel, SessionStreamSnapshot, SessionUiEvent } from "../types.js";
-import { projectBrowserMessage } from "../browserMessageProjection.js";
+import { mediaIdForData, projectBrowserMessage } from "../browserMessageProjection.js";
 import { pageMessagesAtSafeBoundary } from "./messagePaging.js";
 import type { SessionEventHub } from "../realtime/sessionEventHub.js";
 import { BUILTIN_COMMANDS } from "./builtinCommands.js";
@@ -2274,6 +2274,27 @@ export class PiSessionService implements SessionRouteService {
   async messages(ref: PiSessionRef, page?: { before?: number; limit?: number }): Promise<ClientMessagePage> {
     const session = await this.getOrOpen(ref);
     return pageMessagesAtSafeBoundary(historyMessagesFromEntries(await this.readableSessionBranch(ref, session)), page);
+  }
+
+  async media(ref: PiSessionRef, mediaId: string): Promise<{ mimeType: string; data: Buffer } | undefined> {
+    const session = await this.getOrOpen(ref);
+    const entries = await this.readableSessionBranch(ref, session);
+    for (const message of historyMessagesFromEntries(entries)) {
+      const content = isRecord(message) ? message["content"] : undefined;
+      if (!Array.isArray(content)) continue;
+      for (const part of content) {
+        if (!isRecord(part) || part["type"] !== "image") continue;
+        const data = part["data"];
+        if (typeof data !== "string") continue;
+        if (mediaIdForData(data) !== mediaId) continue;
+        const mimeType = part["mimeType"];
+        return {
+          mimeType: typeof mimeType === "string" && mimeType !== "" ? mimeType : "application/octet-stream",
+          data: Buffer.from(data, "base64"),
+        };
+      }
+    }
+    return undefined;
   }
 
   async status(ref: PiSessionRef): Promise<ClientSessionStatus> {

--- a/src/server/sessions/sessionRoutes.test.ts
+++ b/src/server/sessions/sessionRoutes.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { resolve } from "node:path";
 import Fastify, { type FastifyInstance } from "fastify";
 import fastifyWebsocket from "@fastify/websocket";
@@ -877,6 +878,52 @@ describe("session routes", () => {
     }
   });
 
+  it("serves referenced oversized images from the media endpoint by content hash", async () => {
+    const routeApp = Fastify({ logger: false });
+    await routeApp.register(fastifyWebsocket);
+    const eventHub = new SessionEventHub();
+    const routeService = new CapturingRouteSessionService();
+    const bigData = "A".repeat(80 * 1024);
+    const mediaId = createHash("sha256").update(bigData).digest("hex");
+    const message = { role: "toolResult", content: [{ type: "image", mimeType: "image/png", data: bigData }] };
+    routeService.messagesResponse = { messages: [message], start: 0, total: 1 };
+    routeService.mediaResponse = { mimeType: "image/png", data: Buffer.from("png-bytes", "utf8") };
+    registerSessionRoutes(routeApp, routeService, eventHub);
+
+    try {
+      // Without the opt-in parameter oversized images stay fully inline.
+      const unthrottled = await routeApp.inject({ method: "GET", url: `/sessions/session-1/messages?cwd=${encodeURIComponent("/repo")}` });
+      expect(unthrottled.json()).toEqual({ messages: [message], start: 0, total: 1 });
+
+      // With the opt-in parameter oversized images become media references.
+      const page = await routeApp.inject({ method: "GET", url: `/sessions/session-1/messages?cwd=${encodeURIComponent("/repo")}&maxInlineMedia=65536` });
+      const src = `api/machines/local/sessions/session-1/media/${mediaId}?cwd=${encodeURIComponent("/repo")}`;
+      expect(page.json()).toEqual({
+        messages: [
+          { role: "toolResult", content: [{ type: "image", mimeType: "image/png", src, byteSize: 60 * 1024 }] },
+        ],
+        start: 0,
+        total: 1,
+      });
+
+      const served = await routeApp.inject({ method: "GET", url: `/sessions/session-1/media/${mediaId}?cwd=${encodeURIComponent("/repo")}` });
+      expect(served.statusCode).toBe(200);
+      expect(served.headers["cache-control"]).toBe("private, max-age=31536000, immutable");
+      expect(served.json()).toEqual({ mimeType: "image/png", data: Buffer.from("png-bytes", "utf8").toString("base64") });
+
+      // fake 不做哈希校验，显式置空模拟“哈希未命中”
+      routeService.mediaResponse = undefined;
+      const missAfterClear = await routeApp.inject({ method: "GET", url: `/sessions/session-1/media/${"0".repeat(64)}?cwd=${encodeURIComponent("/repo")}` });
+      expect(missAfterClear.statusCode).toBe(404);
+
+      const malformed = await routeApp.inject({ method: "GET", url: "/sessions/session-1/media/not-a-hash?cwd=%2Frepo" });
+      expect(malformed.statusCode).toBe(400);
+    } finally {
+      await routeService.dispose();
+      await routeApp.close();
+    }
+  });
+
   it("forwards prompt attachments and supports the save-attachments route", async () => {
     const routeApp = Fastify({ logger: false });
     await routeApp.register(fastifyWebsocket);
@@ -1215,6 +1262,8 @@ class CapturingRouteSessionService implements SessionRouteService {
   dismissWarningError: Error | undefined;
   unreadError: Error | undefined;
   messagesResponse: MessagePage = { messages: [], start: 0, total: 0 };
+  mediaResponse: { mimeType: string; data: Buffer } | undefined;
+  mediaCalls: { ref: SessionRouteRef; mediaId: string }[] = [];
   streamSnapshotResponse: SessionStreamSnapshot = { seq: 0, partial: null };
   readonly streamSnapshotCalls: SessionRouteRef[] = [];
   readonly cleanupPreviewCalls: NormalizedSessionCleanupRequest[] = [];
@@ -1359,6 +1408,11 @@ class CapturingRouteSessionService implements SessionRouteService {
 
   messages(): Promise<MessagePage> {
     return Promise.resolve(this.messagesResponse);
+  }
+
+  media(ref: SessionRouteRef, mediaId: string): Promise<{ mimeType: string; data: Buffer } | undefined> {
+    this.mediaCalls.push({ ref, mediaId });
+    return Promise.resolve(this.mediaResponse);
   }
 
   status(lookup: SessionRouteRef) {

--- a/src/server/sessions/sessionRoutes.ts
+++ b/src/server/sessions/sessionRoutes.ts
@@ -13,6 +13,15 @@ interface SessionQuery {
 interface MessageQuery extends SessionQuery {
   before?: string;
   limit?: string;
+  /** Opt-in: inline base64 length above which image parts become media references. Absent = inline everything. */
+  maxInlineMedia?: string;
+}
+
+/** Application-relative URL the browser fetches an oversized image from by content hash. */
+function mediaSrcPath(sessionId: string, cwd: string | undefined, mediaId: string): string {
+  const params = new URLSearchParams();
+  if (cwd !== undefined && cwd !== "") params.set("cwd", cwd);
+  return `api/machines/local/sessions/${encodeURIComponent(sessionId)}/media/${encodeURIComponent(mediaId)}?${params.toString()}`;
 }
 
 interface PromptRequestBody {
@@ -165,10 +174,25 @@ export function registerSessionRoutes(app: FastifyInstance, sessions: SessionRou
     if (ref === undefined) return reply;
     try {
       const page = { ...optionalField("before", optionalNumber(request.query.before)), ...optionalField("limit", optionalNumber(request.query.limit)) };
+      const maxInlineMedia = optionalNumber(request.query.maxInlineMedia);
+      const media = maxInlineMedia !== undefined && maxInlineMedia > 0 ? { mediaSrc: (mediaId: string) => mediaSrcPath(request.params.sessionId, request.query.cwd, mediaId), inlineLimit: maxInlineMedia } : undefined;
       const messages = await sessions.messages(ref, page);
-      return projectBrowserMessageResponse(messages);
+      return projectBrowserMessageResponse(messages, media);
     } catch (error) {
       return reply.code(404).send({ error: errorMessage(error) });
+    }
+  });
+
+  app.get<{ Params: { sessionId: string; mediaId: string }; Querystring: SessionQuery }>(`${prefix}/sessions/:sessionId/media/:mediaId`, async (request, reply) => {
+    const ref = sessionRefFromQueryOr400(request.params.sessionId, request.query, reply);
+    if (ref === undefined) return reply;
+    if (!/^[0-9a-f]{64}$/u.test(request.params.mediaId)) return reply.code(400).send({ error: "mediaId must be a sha-256 hex digest" });
+    try {
+      const media = await sessions.media(ref, request.params.mediaId);
+      if (media === undefined) return await reply.code(404).send({ error: "media not found" });
+      return await reply.header("cache-control", "private, max-age=31536000, immutable").send({ mimeType: media.mimeType, data: media.data.toString("base64") });
+    } catch (error) {
+      return await reply.code(404).send({ error: errorMessage(error) });
     }
   });
 

--- a/src/server/sessions/sessionService.ts
+++ b/src/server/sessions/sessionService.ts
@@ -54,6 +54,8 @@ export interface SessionRouteService {
    */
   start(cwd: string, options?: { startupToken?: string }): Promise<ClientSession>;
   messages(ref: SessionRouteRef, page?: { before?: number; limit?: number }): Promise<ClientMessagePage>;
+  /** Locate one oversized inline image by content hash; undefined when no stored image matches. */
+  media(ref: SessionRouteRef, mediaId: string): Promise<{ mimeType: string; data: Buffer } | undefined>;
   status(ref: SessionRouteRef): Promise<ClientSessionStatus>;
   streamSnapshot(ref: SessionRouteRef): Promise<SessionStreamSnapshot>;
   notificationCatalog(): SessionNotificationCatalogSnapshot | Promise<SessionNotificationCatalogSnapshot>;


### PR DESCRIPTION
## What

Server-side capability only: when a messages request opts in with a `maxInlineMedia` query parameter, image parts whose base64 exceeds that length are projected to content-hash media references at the browser transport boundary, and a new session media endpoint serves the original bytes (as JSON with the base64 payload, plus an immutable cache header).

Without the parameter, responses are byte-for-byte identical to today — existing clients are unaffected.

## Why

Sessions whose transcripts carry many tool-result screenshots inline every image as base64, so the first messages page can cost tens of megabytes on slow links. Measured on a real 62MB session: the first page (limit=100) carries 33.7MB, 96% of the session's bytes sit in 60 oversized tool-result images. With `maxInlineMedia=65536` the same page is ~230KB.

## Scope note

This replaces the earlier, larger version of this PR: it is now server-side only (no client, proxy, or daemon-client changes — the media response is JSON so the existing proxy passes it through untouched). A follow-up can opt the client in and render the references lazily.

## Testing

- Projection unit tests: oversized → reference (with `byteSize`), small stays inline, no projection → unchanged, runtime message never mutated
- Route tests: default request unchanged; opted-in request returns references; media endpoint serves base64 + immutable cache header; 404 on unknown hash; 400 on malformed hash
- Verified against a real 62MB session fixture with a Playwright phone-profile harness (4x CPU, 4Mbps, 100ms RTT): first rendered message 53s → 6.4s